### PR TITLE
fix: ensure new users have team data

### DIFF
--- a/src/pages/TeamPlanning.tsx
+++ b/src/pages/TeamPlanning.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { PlayerCard } from '@/components/ui/player-card';
 import { Player } from '@/types';
-import { getTeam, saveTeamPlayers } from '@/services/team';
+import { getTeam, saveTeamPlayers, createInitialTeam } from '@/services/team';
 import { useAuth } from '@/contexts/AuthContext';
 import { Search, Save, Eye, Filter } from 'lucide-react';
 import { toast } from 'sonner';
@@ -38,9 +38,13 @@ export default function TeamPlanning() {
 
   useEffect(() => {
     if (!user) return;
-    getTeam(user.id).then(team => {
-      if (team) setPlayers(team.players);
-    });
+    (async () => {
+      let team = await getTeam(user.id);
+      if (!team) {
+        team = await createInitialTeam(user.id, user.teamName, user.teamName);
+      }
+      setPlayers(team.players);
+    })();
   }, [user]);
 
   const startingEleven = players.filter(p => p.category === 'starting');

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -41,9 +41,14 @@ const generateTeamData = (id: string, name: string, manager: string): ClubTeam =
   };
 };
 
-export const createInitialTeam = async (userId: string, teamName: string, manager: string) => {
+export const createInitialTeam = async (
+  userId: string,
+  teamName: string,
+  manager: string,
+): Promise<ClubTeam> => {
   const team = generateTeamData(userId, teamName, manager);
   await setDoc(doc(db, 'teams', userId), team);
+  return team;
 };
 
 export const getTeam = async (userId: string): Promise<ClubTeam | null> => {


### PR DESCRIPTION
## Summary
- return team data from `createInitialTeam`
- populate and save a starter team if user has none during team planning

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c2a595f8832a97a6fc47c479f1b1