### PR TITLE
Ensure team persistence and youth promotions

### DIFF
--- a/src/pages/Youth.tsx
+++ b/src/pages/Youth.tsx
@@ -8,9 +8,12 @@ import { Player } from '@/types';
 import { UserPlus, Plus, Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import { addPlayerToTeam } from '@/services/team';
 
 export default function Youth() {
   const navigate = useNavigate();
+  const { user } = useAuth();
   const [players, setPlayers] = useState<Player[]>(youthPlayers);
   const [isGenerating, setIsGenerating] = useState(false);
 
@@ -45,9 +48,10 @@ export default function Youth() {
     }, 2000);
   };
 
-  const promotePlayer = (playerId: string) => {
+  const promotePlayer = async (playerId: string) => {
     const player = players.find(p => p.id === playerId);
-    if (player) {
+    if (player && user) {
+      await addPlayerToTeam(user.id, player);
       setPlayers(prev => prev.filter(p => p.id !== playerId));
       toast.success(`${player.name} takıma transfer edildi!`);
     }

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -59,3 +59,14 @@ export const getTeam = async (userId: string): Promise<ClubTeam | null> => {
 export const saveTeamPlayers = async (userId: string, players: Player[]) => {
   await setDoc(doc(db, 'teams', userId), { players }, { merge: true });
 };
+
+export const addPlayerToTeam = async (userId: string, player: Player) => {
+  const team = await getTeam(userId);
+  if (!team) return;
+  const updatedPlayers = [
+    ...team.players,
+    { ...player, category: 'reserve' as const },
+  ];
+  await setDoc(doc(db, 'teams', userId), { players: updatedPlayers }, { merge: true });
+  return updatedPlayers;
+};


### PR DESCRIPTION
## Summary
- Create or restore a user's team on sign in so the squad is always available
- Add backend helper to promote youth players into the club and persist to Firestore
- Wire youth page to persist promoted players

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4c7f62888832a8ad00992d144edeb