### PR TITLE
Add selectable formations and visual lineup

### DIFF
--- a/src/lib/formations.ts
+++ b/src/lib/formations.ts
@@ -1,0 +1,64 @@
+import { Player } from '@/types';
+
+export interface FormationPosition {
+  position: Player['position'];
+  x: number; // percentage from 0 to 100
+  y: number; // percentage from 0 to 100
+}
+
+export interface Formation {
+  name: string;
+  positions: FormationPosition[];
+}
+
+export const formations: Formation[] = [
+  {
+    name: '4-4-2',
+    positions: [
+      { position: 'GK', x: 50, y: 90 },
+      { position: 'LB', x: 15, y: 70 },
+      { position: 'CB', x: 35, y: 65 },
+      { position: 'CB', x: 65, y: 65 },
+      { position: 'RB', x: 85, y: 70 },
+      { position: 'LM', x: 15, y: 45 },
+      { position: 'CM', x: 40, y: 45 },
+      { position: 'CM', x: 60, y: 45 },
+      { position: 'RM', x: 85, y: 45 },
+      { position: 'ST', x: 40, y: 20 },
+      { position: 'ST', x: 60, y: 20 },
+    ],
+  },
+  {
+    name: '4-3-3',
+    positions: [
+      { position: 'GK', x: 50, y: 90 },
+      { position: 'LB', x: 15, y: 70 },
+      { position: 'CB', x: 35, y: 65 },
+      { position: 'CB', x: 65, y: 65 },
+      { position: 'RB', x: 85, y: 70 },
+      { position: 'CM', x: 30, y: 45 },
+      { position: 'CM', x: 50, y: 40 },
+      { position: 'CM', x: 70, y: 45 },
+      { position: 'LW', x: 20, y: 25 },
+      { position: 'ST', x: 50, y: 15 },
+      { position: 'RW', x: 80, y: 25 },
+    ],
+  },
+  {
+    name: '3-5-2',
+    positions: [
+      { position: 'GK', x: 50, y: 90 },
+      { position: 'CB', x: 30, y: 70 },
+      { position: 'CB', x: 50, y: 65 },
+      { position: 'CB', x: 70, y: 70 },
+      { position: 'LM', x: 10, y: 45 },
+      { position: 'CM', x: 30, y: 45 },
+      { position: 'CAM', x: 50, y: 40 },
+      { position: 'CM', x: 70, y: 45 },
+      { position: 'RM', x: 90, y: 45 },
+      { position: 'ST', x: 40, y: 20 },
+      { position: 'ST', x: 60, y: 20 },
+    ],
+  },
+];
+

--- a/src/pages/TeamPlanning.tsx
+++ b/src/pages/TeamPlanning.tsx
@@ -10,6 +10,14 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Search, Save, Eye, Filter } from 'lucide-react';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { formations } from '@/lib/formations';
 
 export default function TeamPlanning() {
   const navigate = useNavigate();
@@ -17,6 +25,9 @@ export default function TeamPlanning() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [activeTab, setActiveTab] = useState('starting');
+  const [selectedFormation, setSelectedFormation] = useState(
+    formations[0].name
+  );
 
   const filteredPlayers = players.filter(player => 
     player.name.toLowerCase().includes(searchTerm.toLowerCase()) &&
@@ -50,6 +61,20 @@ export default function TeamPlanning() {
   const startingEleven = players.filter(p => p.squadRole === 'starting');
   const benchPlayers = players.filter(p => p.squadRole === 'bench');
   const reservePlayers = players.filter(p => p.squadRole === 'reserve');
+
+  const currentFormation = formations.find(
+    f => f.name === selectedFormation
+  )!;
+  const formationPositions = (() => {
+    const used = new Set<string>();
+    return currentFormation.positions.map(pos => {
+      const player = startingEleven.find(
+        p => p.position === pos.position && !used.has(p.id)
+      );
+      if (player) used.add(player.id);
+      return { ...pos, player };
+    });
+  })();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 dark:from-green-950 dark:via-emerald-950 dark:to-teal-950">
@@ -97,24 +122,45 @@ export default function TeamPlanning() {
 
         {/* Team Formation Overview */}
         <Card className="mb-6">
-          <CardHeader>
+          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <CardTitle className="flex items-center gap-2">
               <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-              Formasyon Görünümü (4-4-2)
+              Formasyon Görünümü ({selectedFormation})
             </CardTitle>
+            <Select value={selectedFormation} onValueChange={setSelectedFormation}>
+              <SelectTrigger className="w-40">
+                <SelectValue placeholder="Formasyon" />
+              </SelectTrigger>
+              <SelectContent>
+                {formations.map(f => (
+                  <SelectItem key={f.name} value={f.name}>
+                    {f.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </CardHeader>
           <CardContent>
-            <div className="bg-gradient-to-b from-green-400 to-green-600 rounded-lg p-4 relative h-40">
-              <div className="text-white text-center text-sm font-semibold">
+            <div className="bg-gradient-to-b from-green-400 to-green-600 rounded-lg p-4 relative h-96">
+              <div className="text-white text-center text-sm font-semibold mb-2">
                 {startingEleven.length}/11 oyuncu seçildi
               </div>
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="grid grid-cols-4 gap-2 text-white text-xs">
-                  <div className="text-center">GK<br/>1</div>
-                  <div className="text-center">DEF<br/>4</div>
-                  <div className="text-center">MID<br/>4</div>
-                  <div className="text-center">ATT<br/>2</div>
-                </div>
+              <div className="absolute inset-0">
+                {formationPositions.map(({ player, position, x, y }, idx) => (
+                  <div
+                    key={idx}
+                    className="absolute text-xs text-center"
+                    style={{
+                      left: `${x}%`,
+                      top: `${y}%`,
+                      transform: 'translate(-50%, -50%)',
+                    }}
+                  >
+                    <div className="w-12 h-12 rounded-full bg-white/80 flex items-center justify-center">
+                      {player ? player.name.split(' ')[0] : position}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary
- add predefined formation data for 4-4-2, 4-3-3, 3-5-2
- allow formation selection in team planning and render players on field positions

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4e094f478832a88af40cda322cf51