### PR TITLE
Fix training session reset on navigation

### DIFF
--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -32,7 +32,7 @@ export default function TrainingPage() {
 
   // Restore training session from localStorage if it exists
   useEffect(() => {
-    if (!user) return;
+    if (!user || players.length === 0) return;
     const sessionStr = localStorage.getItem('activeTraining');
     if (!sessionStr) return;
 


### PR DESCRIPTION
## Summary
- ensure active training is restored only after players load

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f11c8c7c832a876e0f965d992d01