### PR TITLE
feat: add diamond currency with mock purchase flow

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+      match /diamondPurchases/{purchaseId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint --quiet ./src",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -80,6 +81,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 import { ThemeProvider } from '@/contexts/ThemeContext';
+import { DiamondProvider } from '@/contexts/DiamondContext';
+import TopBar from '@/components/layout/TopBar';
 
 // Pages
 import Auth from './pages/Auth';
@@ -18,6 +20,7 @@ import MatchSimulation from './pages/MatchSimulation';
 import Finance from './pages/Finance';
 import Settings from './pages/Settings';
 import NotFound from './pages/NotFound';
+import DiamondsPage from '@/features/diamonds/DiamondsPage';
 
 const queryClient = new QueryClient();
 
@@ -29,21 +32,25 @@ const AppContent = () => {
   }
 
   return (
-    <Routes>
-      <Route path="/" element={<MainMenu />} />
-      <Route path="/team-planning" element={<TeamPlanning />} />
-      <Route path="/youth" element={<Youth />} />
-      <Route path="/fixtures" element={<Fixtures />} />
-      <Route path="/leagues" element={<Leagues />} />
-      <Route path="/training" element={<Training />} />
-      <Route path="/match-preview" element={<MatchPreview />} />
-      <Route path="/match-simulation" element={<MatchSimulation />} />
-      <Route path="/match-history" element={<Fixtures />} />
-      <Route path="/finance" element={<Finance />} />
-      <Route path="/profile" element={<Settings />} />
-      <Route path="/settings" element={<Settings />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <>
+      <TopBar />
+      <Routes>
+        <Route path="/" element={<MainMenu />} />
+        <Route path="/team-planning" element={<TeamPlanning />} />
+        <Route path="/youth" element={<Youth />} />
+        <Route path="/fixtures" element={<Fixtures />} />
+        <Route path="/leagues" element={<Leagues />} />
+        <Route path="/training" element={<Training />} />
+        <Route path="/match-preview" element={<MatchPreview />} />
+        <Route path="/match-simulation" element={<MatchSimulation />} />
+        <Route path="/match-history" element={<Fixtures />} />
+        <Route path="/finance" element={<Finance />} />
+        <Route path="/profile" element={<Settings />} />
+        <Route path="/settings" element={<Settings />} />
+        <Route path="/store/diamonds" element={<DiamondsPage />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </>
   );
 };
 
@@ -52,10 +59,12 @@ const App = () => (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <AuthProvider>
-          <TooltipProvider>
-            <Toaster />
-            <AppContent />
-          </TooltipProvider>
+          <DiamondProvider>
+            <TooltipProvider>
+              <Toaster />
+              <AppContent />
+            </TooltipProvider>
+          </DiamondProvider>
         </AuthProvider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,0 +1,16 @@
+import { Diamond } from 'lucide-react';
+import { useDiamonds } from '@/contexts/DiamondContext';
+
+const TopBar = () => {
+  const { balance } = useDiamonds();
+  return (
+    <div className="flex justify-end items-center p-4 border-b">
+      <div className="flex items-center gap-1">
+        <Diamond className="h-5 w-5 text-blue-500" />
+        <span>{balance}</span>
+      </div>
+    </div>
+  );
+};
+
+export default TopBar;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { onAuthStateChanged, updateProfile } from 'firebase/auth';
 import { User } from '@/types';
-import { auth } from '@/firebase';
+import { auth } from '@/services/firebase';
 import { signIn, signUp, signOutUser } from '@/services/auth';
 import { createInitialTeam, getTeam } from '@/services/team';
 import { generateRandomName } from '@/lib/names';

--- a/src/contexts/DiamondContext.tsx
+++ b/src/contexts/DiamondContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  ensureUserDoc,
+  listenDiamondBalance,
+  mockPurchaseDiamonds,
+  DiamondPack,
+} from '@/services/diamonds';
+
+interface DiamondContextValue {
+  balance: number;
+  purchase: (pack: DiamondPack) => Promise<void>;
+}
+
+const DiamondContext = createContext<DiamondContextValue | undefined>(undefined);
+
+export const DiamondProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const { user } = useAuth();
+  const [balance, setBalance] = useState(0);
+
+  useEffect(() => {
+    if (!user) return;
+    ensureUserDoc(user.id);
+    const unsub = listenDiamondBalance(user.id, (b) => setBalance(b));
+    return () => unsub();
+  }, [user]);
+
+  const purchase = async (pack: DiamondPack) => {
+    if (!user) return;
+    await mockPurchaseDiamonds(user.id, pack);
+  };
+
+  return (
+    <DiamondContext.Provider value={{ balance, purchase }}>
+      {children}
+    </DiamondContext.Provider>
+  );
+};
+
+export const useDiamonds = () => {
+  const ctx = useContext(DiamondContext);
+  if (!ctx) throw new Error('useDiamonds must be used within DiamondProvider');
+  return ctx;
+};

--- a/src/features/diamonds/CheckoutModal.tsx
+++ b/src/features/diamonds/CheckoutModal.tsx
@@ -1,0 +1,35 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useDiamonds } from '@/contexts/DiamondContext';
+import type { DiamondPack } from '@/services/diamonds';
+
+interface Props {
+  pack: DiamondPack | null;
+  onClose: () => void;
+}
+
+const CheckoutModal: React.FC<Props> = ({ pack, onClose }) => {
+  const { purchase } = useDiamonds();
+
+  const handleConfirm = async () => {
+    if (!pack) return;
+    await purchase(pack);
+    onClose();
+  };
+
+  return (
+    <Dialog open={!!pack} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Kripto ile ödeme</DialogTitle>
+        </DialogHeader>
+        <p>Cüzdan bağlandı (mock)</p>
+        <DialogFooter>
+          <Button onClick={handleConfirm}>Ödemeyi onayla</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CheckoutModal;

--- a/src/features/diamonds/DiamondsPage.tsx
+++ b/src/features/diamonds/DiamondsPage.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import CheckoutModal from './CheckoutModal';
+import { DIAMOND_PACKS } from './packs';
+import type { DiamondPack } from '@/services/diamonds';
+
+const DiamondsPage = () => {
+  const [selected, setSelected] = useState<DiamondPack | null>(null);
+
+  return (
+    <div className="p-4 grid gap-4 md:grid-cols-3">
+      {DIAMOND_PACKS.map((pack) => (
+        <Card key={pack.id}>
+          <CardHeader>
+            <CardTitle>{pack.label}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            <span>{pack.amount} elmas</span>
+            <span>₺{pack.price.toFixed(2)}</span>
+            <Button onClick={() => setSelected(pack)}>Kripto ile öde</Button>
+          </CardContent>
+        </Card>
+      ))}
+      <CheckoutModal pack={selected} onClose={() => setSelected(null)} />
+    </div>
+  );
+};
+
+export default DiamondsPage;

--- a/src/features/diamonds/packs.ts
+++ b/src/features/diamonds/packs.ts
@@ -1,0 +1,8 @@
+import type { DiamondPack } from '@/services/diamonds';
+
+export const DIAMOND_PACKS: DiamondPack[] = [
+  { id: 'small', label: 'Small', amount: 80, price: 39.99 },
+  { id: 'medium', label: 'Medium', amount: 500, price: 199.99 },
+  { id: 'large', label: 'Large', amount: 1200, price: 399.99 },
+];
+

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -3,7 +3,7 @@ import {
   signInWithEmailAndPassword,
   signOut,
 } from "firebase/auth";
-import { auth } from "../firebase";
+import { auth } from "./firebase";
 
 export const signUp = (email: string, password: string) =>
   createUserWithEmailAndPassword(auth, email, password);

--- a/src/services/diamonds.test.ts
+++ b/src/services/diamonds.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ensureUserDoc } from './diamonds';
+
+vi.mock('./firebase', () => ({ db: {} }));
+
+const docMock = vi.fn();
+const getDocMock = vi.fn();
+const setDocMock = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: unknown[]) => docMock(...args),
+  getDoc: (...args: unknown[]) => getDocMock(...args),
+  setDoc: (...args: unknown[]) => setDocMock(...args),
+}));
+
+describe('ensureUserDoc', () => {
+  beforeEach(() => {
+    docMock.mockReturnValue('ref');
+    getDocMock.mockReset();
+    setDocMock.mockReset();
+  });
+
+  it('creates document if missing', async () => {
+    getDocMock.mockResolvedValue({ exists: () => false });
+    await ensureUserDoc('uid');
+    expect(setDocMock).toHaveBeenCalledWith('ref', { diamondBalance: 0 });
+  });
+
+  it('skips creation if document exists', async () => {
+    getDocMock.mockResolvedValue({ exists: () => true });
+    await ensureUserDoc('uid');
+    expect(setDocMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/diamonds.ts
+++ b/src/services/diamonds.ts
@@ -1,0 +1,66 @@
+import {
+  doc,
+  getDoc,
+  setDoc,
+  onSnapshot,
+  Unsubscribe,
+  runTransaction,
+  increment,
+  collection,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { db } from './firebase';
+import { toast } from 'sonner';
+
+export interface DiamondPack {
+  id: string;
+  label: string;
+  amount: number;
+  price: number;
+}
+
+export async function ensureUserDoc(uid: string): Promise<void> {
+  const ref = doc(db, 'users', uid);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) {
+    await setDoc(ref, { diamondBalance: 0 });
+  }
+}
+
+export function listenDiamondBalance(
+  uid: string,
+  cb: (balance: number) => void,
+): Unsubscribe {
+  const ref = doc(db, 'users', uid);
+  return onSnapshot(ref, (snap) => {
+    const data = snap.data();
+    cb(data?.diamondBalance ?? 0);
+  });
+}
+
+export async function mockPurchaseDiamonds(
+  uid: string,
+  pack: DiamondPack,
+): Promise<void> {
+  const userRef = doc(db, 'users', uid);
+  const purchases = collection(userRef, 'diamondPurchases');
+  try {
+    await runTransaction(db, async (tx) => {
+      tx.update(userRef, { diamondBalance: increment(pack.amount) });
+      const purchaseRef = doc(purchases);
+      tx.set(purchaseRef, {
+        packId: pack.id,
+        amount: pack.amount,
+        priceFiat: pack.price,
+        paymentMethod: 'mock-crypto',
+        status: 'mock_paid',
+        createdAt: serverTimestamp(),
+      });
+    });
+    toast.success('Ödeme tamamlandı');
+  } catch (err) {
+    console.error(err);
+    toast.error('Ödeme başarısız');
+    throw err;
+  }
+}

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -17,3 +17,4 @@ console.log(
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -1,5 +1,5 @@
 import { doc, setDoc, getDoc } from 'firebase/firestore';
-import { db } from '@/firebase';
+import { db } from '@/services/firebase';
 import { Player, ClubTeam } from '@/types';
 import { generateRandomName } from '@/lib/names';
 


### PR DESCRIPTION
## Summary
- add firebase diamond services and context
- show live diamond balance in top bar
- implement mock diamond store with checkout modal
- include Firestore security rules for user diamonds

## Testing
- `pnpm lint`
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a61262ddac832a87f16f3f8d76a982