### PR TITLE
feat: add diamond store and topbar flow

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,14 +1,27 @@
-import { Diamond } from 'lucide-react';
+import { Diamond, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
 import { useDiamonds } from '@/contexts/DiamondContext';
 
 const TopBar = () => {
   const { balance } = useDiamonds();
+  const navigate = useNavigate();
+
   return (
     <div className="flex justify-end items-center p-4 border-b">
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1" data-testid="topbar-diamond-balance">
         <Diamond className="h-5 w-5 text-blue-500" />
         <span>{balance}</span>
       </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="ml-2"
+        onClick={() => navigate('/store/diamonds')}
+        data-testid="topbar-diamond-plus"
+      >
+        <Plus className="h-4 w-4" />
+      </Button>
     </div>
   );
 };

--- a/src/contexts/DiamondContext.tsx
+++ b/src/contexts/DiamondContext.tsx
@@ -1,11 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import {
-  ensureUserDoc,
-  listenDiamondBalance,
-  mockPurchaseDiamonds,
-  DiamondPack,
-} from '@/services/diamonds';
+import { ensureUserDoc, listenDiamondBalance, mockPurchaseDiamonds } from '@/services/diamonds';
+import type { DiamondPack } from '@/features/diamonds/packs';
 
 interface DiamondContextValue {
   balance: number;
@@ -27,7 +23,11 @@ export const DiamondProvider: React.FC<{ children: ReactNode }> = ({ children })
 
   const purchase = async (pack: DiamondPack) => {
     if (!user) return;
-    await mockPurchaseDiamonds(user.id, pack);
+    await mockPurchaseDiamonds(user.id, {
+      packId: pack.id,
+      amount: pack.amount,
+      priceFiat: pack.priceFiat,
+    });
   };
 
   return (

--- a/src/features/diamonds/CheckoutModal.tsx
+++ b/src/features/diamonds/CheckoutModal.tsx
@@ -1,7 +1,7 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useDiamonds } from '@/contexts/DiamondContext';
-import type { DiamondPack } from '@/services/diamonds';
+import type { DiamondPack } from './packs';
 
 interface Props {
   pack: DiamondPack | null;
@@ -23,9 +23,17 @@ const CheckoutModal: React.FC<Props> = ({ pack, onClose }) => {
         <DialogHeader>
           <DialogTitle>Kripto ile ödeme</DialogTitle>
         </DialogHeader>
-        <p>Cüzdan bağlandı (mock)</p>
+        <p>Cüzdan bağlandı (simülasyon)</p>
+        {pack && (
+          <div className="mt-4 space-y-1 text-sm">
+            <div>Ağ ücreti: ~0.001 ETH</div>
+            {pack.priceFiat && <div>Toplam: ₺{pack.priceFiat.toFixed(2)}</div>}
+          </div>
+        )}
         <DialogFooter>
-          <Button onClick={handleConfirm}>Ödemeyi onayla</Button>
+          <Button onClick={handleConfirm} data-testid="checkout-confirm">
+            Ödemeyi Onayla
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/diamonds/DiamondsPage.tsx
+++ b/src/features/diamonds/DiamondsPage.tsx
@@ -1,27 +1,24 @@
 import { useState } from 'react';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
 import CheckoutModal from './CheckoutModal';
-import { DIAMOND_PACKS } from './packs';
-import type { DiamondPack } from '@/services/diamonds';
+import PacksGrid from './PacksGrid';
+import { DIAMOND_PACKS, DiamondPack } from './packs';
 
 const DiamondsPage = () => {
+  const { user } = useAuth();
   const [selected, setSelected] = useState<DiamondPack | null>(null);
 
+  if (!user) {
+    return <div className="p-4 text-center">Giriş yapmalısın</div>;
+  }
+
   return (
-    <div className="p-4 grid gap-4 md:grid-cols-3">
-      {DIAMOND_PACKS.map((pack) => (
-        <Card key={pack.id}>
-          <CardHeader>
-            <CardTitle>{pack.label}</CardTitle>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-2">
-            <span>{pack.amount} elmas</span>
-            <span>₺{pack.price.toFixed(2)}</span>
-            <Button onClick={() => setSelected(pack)}>Kripto ile öde</Button>
-          </CardContent>
-        </Card>
-      ))}
+    <div className="p-4 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">Elmas Mağazası</h1>
+        <p className="text-muted-foreground">Oyun deneyimini geliştirmek için elmas satın al.</p>
+      </div>
+      <PacksGrid packs={DIAMOND_PACKS} onSelect={setSelected} />
       <CheckoutModal pack={selected} onClose={() => setSelected(null)} />
     </div>
   );

--- a/src/features/diamonds/PacksGrid.tsx
+++ b/src/features/diamonds/PacksGrid.tsx
@@ -1,0 +1,46 @@
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Diamond } from 'lucide-react';
+import type { DiamondPack } from './packs';
+
+interface Props {
+  packs: DiamondPack[];
+  onSelect: (pack: DiamondPack) => void;
+}
+
+const PacksGrid: React.FC<Props> = ({ packs, onSelect }) => (
+  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+    {packs.map((pack) => (
+      <Card
+        key={pack.id}
+        data-testid={`diamond-pack-${pack.id}`}
+        className="hover:shadow-md transition-transform hover:scale-105"
+      >
+        <CardHeader>
+          <CardTitle className="flex justify-between items-center">
+            <span>{pack.label}</span>
+            {pack.bestDeal && <span className="text-xs text-green-600">Best Deal</span>}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-2">
+          <Diamond className="h-6 w-6 text-blue-500" />
+          <span className="text-lg font-bold">{pack.amount}</span>
+          {pack.priceFiat && (
+            <span className="text-sm text-muted-foreground">₺{pack.priceFiat.toFixed(2)}</span>
+          )}
+        </CardContent>
+        <CardFooter>
+          <Button
+            className="w-full"
+            onClick={() => onSelect(pack)}
+            data-testid={`diamond-buy-${pack.id}`}
+          >
+            Satın Al
+          </Button>
+        </CardFooter>
+      </Card>
+    ))}
+  </div>
+);
+
+export default PacksGrid;

--- a/src/features/diamonds/packs.ts
+++ b/src/features/diamonds/packs.ts
@@ -1,8 +1,14 @@
-import type { DiamondPack } from '@/services/diamonds';
+export type DiamondPack = {
+  id: 'small' | 'medium' | 'large' | 'mega';
+  amount: number;
+  priceFiat?: number;
+  label: string;
+  bestDeal?: boolean;
+};
 
 export const DIAMOND_PACKS: DiamondPack[] = [
-  { id: 'small', label: 'Small', amount: 80, price: 39.99 },
-  { id: 'medium', label: 'Medium', amount: 500, price: 199.99 },
-  { id: 'large', label: 'Large', amount: 1200, price: 399.99 },
+  { id: 'small', amount: 80, priceFiat: 39.99, label: 'Small' },
+  { id: 'medium', amount: 500, priceFiat: 199.99, label: 'Medium', bestDeal: true },
+  { id: 'large', amount: 1200, priceFiat: 399.99, label: 'Large' },
+  { id: 'mega', amount: 2500, priceFiat: 749.99, label: 'Mega' },
 ];
-

--- a/src/services/diamonds.ts
+++ b/src/services/diamonds.ts
@@ -12,13 +12,6 @@ import {
 import { db } from './firebase';
 import { toast } from 'sonner';
 
-export interface DiamondPack {
-  id: string;
-  label: string;
-  amount: number;
-  price: number;
-}
-
 export async function ensureUserDoc(uid: string): Promise<void> {
   const ref = doc(db, 'users', uid);
   const snap = await getDoc(ref);
@@ -40,18 +33,18 @@ export function listenDiamondBalance(
 
 export async function mockPurchaseDiamonds(
   uid: string,
-  pack: DiamondPack,
+  { packId, amount, priceFiat }: { packId: string; amount: number; priceFiat?: number },
 ): Promise<void> {
   const userRef = doc(db, 'users', uid);
   const purchases = collection(userRef, 'diamondPurchases');
   try {
     await runTransaction(db, async (tx) => {
-      tx.update(userRef, { diamondBalance: increment(pack.amount) });
+      tx.update(userRef, { diamondBalance: increment(amount) });
       const purchaseRef = doc(purchases);
       tx.set(purchaseRef, {
-        packId: pack.id,
-        amount: pack.amount,
-        priceFiat: pack.price,
+        packId,
+        amount,
+        priceFiat,
         paymentMethod: 'mock-crypto',
         status: 'mock_paid',
         createdAt: serverTimestamp(),
@@ -59,7 +52,7 @@ export async function mockPurchaseDiamonds(
     });
     toast.success('Ödeme tamamlandı');
   } catch (err) {
-    console.error(err);
+    console.warn(err);
     toast.error('Ödeme başarısız');
     throw err;
   }


### PR DESCRIPTION
## Summary
- add diamond balance UI with + shortcut in top bar
- introduce diamond store with purchase modal and packs grid
- wire up mock Firestore purchase flow and realtime balance updates

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6159051ec832a923667e7c0f085fe