### PR TITLE
feat: add academy candidate system with cooldown reset

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,7 +3,7 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /users/{uid} {
       allow read, write: if request.auth != null && request.auth.uid == uid;
-      match /diamondPurchases/{purchaseId} {
+      match /{document=**} {
         allow read, write: if request.auth != null && request.auth.uid == uid;
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import Finance from './pages/Finance';
 import Settings from './pages/Settings';
 import NotFound from './pages/NotFound';
 import DiamondsPage from '@/features/diamonds/DiamondsPage';
+import AcademyPage from '@/features/academy/AcademyPage';
 
 const queryClient = new QueryClient();
 
@@ -48,6 +49,7 @@ const AppContent = () => {
         <Route path="/profile" element={<Settings />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/store/diamonds" element={<DiamondsPage />} />
+        <Route path="/academy" element={<AcademyPage />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/src/features/academy/AcademyPage.tsx
+++ b/src/features/academy/AcademyPage.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/services/firebase';
+import { useAuth } from '@/contexts/AuthContext';
+import { useDiamonds } from '@/contexts/DiamondContext';
+import {
+  listenPendingCandidates,
+  pullNewCandidate,
+  resetCooldownWithDiamonds,
+  acceptCandidate,
+  releaseCandidate,
+  AcademyCandidate,
+} from '@/services/academy';
+import CooldownPanel from './CooldownPanel';
+import CandidatesList from './CandidatesList';
+
+const AcademyPage = () => {
+  const { user } = useAuth();
+  const { balance } = useDiamonds();
+  const [nextPullAt, setNextPullAt] = useState<Date | null>(null);
+  const [candidates, setCandidates] = useState<AcademyCandidate[]>([]);
+
+  useEffect(() => {
+    if (!user) return;
+    const ref = doc(db, 'users', user.id);
+    return onSnapshot(ref, (snap) => {
+      const data = snap.data() as { academy?: { nextPullAt?: { toDate: () => Date } } } | undefined;
+      const ts = data?.academy?.nextPullAt;
+      setNextPullAt(ts ? ts.toDate() : null);
+    });
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    return listenPendingCandidates(user.id, setCandidates);
+  }, [user]);
+
+  const handlePull = async () => {
+    if (!user) return;
+    await pullNewCandidate(user.id);
+  };
+
+  const handleReset = async () => {
+    if (!user) return;
+    await resetCooldownWithDiamonds(user.id);
+  };
+
+  const handleAccept = async (id: string) => {
+    if (!user) return;
+    await acceptCandidate(user.id, id);
+  };
+
+  const handleRelease = async (id: string) => {
+    if (!user) return;
+    await releaseCandidate(user.id, id);
+  };
+
+  if (!user) {
+    return <div className="p-4">Giriş yapmalısın</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">Altyapı</h1>
+        <p className="text-muted-foreground">Yeni oyuncu adaylarını keşfet.</p>
+      </div>
+      <CooldownPanel
+        nextPullAt={nextPullAt}
+        onPull={handlePull}
+        onReset={handleReset}
+        canReset={balance >= 100}
+      />
+      <CandidatesList
+        candidates={candidates}
+        onAccept={handleAccept}
+        onRelease={handleRelease}
+      />
+    </div>
+  );
+};
+
+export default AcademyPage;

--- a/src/features/academy/CandidateCard.tsx
+++ b/src/features/academy/CandidateCard.tsx
@@ -1,0 +1,51 @@
+import { AcademyCandidate } from '@/services/academy';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  candidate: AcademyCandidate;
+  onAccept: () => void;
+  onRelease: () => void;
+}
+
+const CandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease }) => {
+  const { id, player } = candidate;
+  return (
+    <Card data-testid={`academy-candidate-${id}`} className="relative">
+      <div className="absolute top-2 right-2 flex gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onAccept}
+          data-testid={`academy-accept-${id}`}
+        >
+          Takıma Al
+        </Button>
+        <Button
+          size="sm"
+          variant="destructive"
+          onClick={onRelease}
+          data-testid={`academy-release-${id}`}
+        >
+          Serbest Bırak
+        </Button>
+      </div>
+      <CardHeader>
+        <CardTitle>
+          {player.name} ({player.position})
+        </CardTitle>
+        <CardDescription>{player.age} yaş</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        <div>
+          OVR: {player.overall} POT: {player.potential}
+        </div>
+        {player.traits && player.traits.length > 0 && (
+          <div>Özellikler: {player.traits.join(', ')}</div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CandidateCard;

--- a/src/features/academy/CandidatesList.tsx
+++ b/src/features/academy/CandidatesList.tsx
@@ -1,0 +1,28 @@
+import CandidateCard from './CandidateCard';
+import { AcademyCandidate } from '@/services/academy';
+
+interface Props {
+  candidates: AcademyCandidate[];
+  onAccept: (id: string) => void;
+  onRelease: (id: string) => void;
+}
+
+const CandidatesList: React.FC<Props> = ({ candidates, onAccept, onRelease }) => {
+  if (candidates.length === 0) {
+    return <p className="text-sm text-muted-foreground">Henüz aday yok</p>;
+  }
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {candidates.map((c) => (
+        <CandidateCard
+          key={c.id}
+          candidate={c}
+          onAccept={() => onAccept(c.id)}
+          onRelease={() => onRelease(c.id)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CandidatesList;

--- a/src/features/academy/CooldownPanel.tsx
+++ b/src/features/academy/CooldownPanel.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  nextPullAt: Date | null;
+  onPull: () => void;
+  onReset: () => void;
+  canReset: boolean;
+}
+
+const CooldownPanel: React.FC<Props> = ({ nextPullAt, onPull, onReset, canReset }) => {
+  const [remaining, setRemaining] = useState(0);
+
+  useEffect(() => {
+    const tick = () => {
+      if (!nextPullAt) {
+        setRemaining(0);
+        return;
+      }
+      const diff = nextPullAt.getTime() - Date.now();
+      setRemaining(diff > 0 ? diff : 0);
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [nextPullAt]);
+
+  const canPull = remaining === 0;
+  const minutes = Math.floor(remaining / 60000);
+  const seconds = Math.floor((remaining % 60000) / 1000)
+    .toString()
+    .padStart(2, '0');
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button onClick={onPull} disabled={!canPull} data-testid="academy-pull">
+        Aday Çek
+      </Button>
+      <Button
+        onClick={onReset}
+        disabled={!canReset}
+        variant="secondary"
+        data-testid="academy-reset"
+      >
+        Süreyi Sıfırla (100💎)
+      </Button>
+      {!canPull && (
+        <span className="text-sm text-muted-foreground">
+          Kalan: {minutes}:{seconds}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default CooldownPanel;

--- a/src/features/academy/generateMockCandidate.ts
+++ b/src/features/academy/generateMockCandidate.ts
@@ -1,0 +1,33 @@
+export interface CandidatePlayer {
+  name: string;
+  age: number;
+  position: string;
+  overall: number;
+  potential: number;
+  traits: string[];
+}
+
+const NAMES = ['Ahmet', 'Mehmet', 'Ali', 'Can', 'Emre', 'Mert'];
+const POSITIONS = ['GK', 'DEF', 'MID', 'FWD'];
+const TRAITS = ['Hızlı', 'Güçlü', 'Teknik', 'Dayanıklı'];
+
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export function generateMockCandidate(): CandidatePlayer {
+  const overall = randomInt(50, 70);
+  const potential = Math.min(90, overall + randomInt(5, 20));
+  return {
+    name: pick(NAMES),
+    age: randomInt(16, 19),
+    position: pick(POSITIONS),
+    overall,
+    potential,
+    traits: [pick(TRAITS)],
+  };
+}

--- a/src/services/academy.test.ts
+++ b/src/services/academy.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resetCooldownWithDiamonds } from './academy';
+
+vi.mock('./firebase', () => ({ db: {} }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const docMock = vi.fn();
+const runTransactionMock = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: unknown[]) => docMock(...args),
+  runTransaction: (...args: unknown[]) => runTransactionMock(...args),
+  serverTimestamp: vi.fn(),
+  Timestamp: { fromDate: vi.fn() },
+  increment: vi.fn(),
+}));
+
+describe('resetCooldownWithDiamonds', () => {
+  it('throws when not enough diamonds', async () => {
+    runTransactionMock.mockImplementation(async (_db, fn) => {
+      await fn({
+        get: async () => ({ data: () => ({ diamondBalance: 50 }) }),
+        update: vi.fn(),
+      });
+    });
+    await expect(resetCooldownWithDiamonds('uid')).rejects.toThrow('Yetersiz elmas');
+  });
+});

--- a/src/services/academy.ts
+++ b/src/services/academy.ts
@@ -1,0 +1,149 @@
+import {
+  collection,
+  doc,
+  onSnapshot,
+  query,
+  where,
+  orderBy,
+  Unsubscribe,
+  runTransaction,
+  serverTimestamp,
+  Timestamp,
+  increment,
+  deleteDoc,
+} from 'firebase/firestore';
+import { db } from './firebase';
+import { toast } from 'sonner';
+import { generateMockCandidate, CandidatePlayer } from '@/features/academy/generateMockCandidate';
+
+interface UserDoc {
+  diamondBalance?: number;
+  academy?: {
+    nextPullAt?: Timestamp;
+  };
+}
+
+export interface AcademyCandidate {
+  id: string;
+  status: 'pending' | 'accepted' | 'released';
+  createdAt: Timestamp;
+  player: CandidatePlayer;
+  source?: string;
+}
+
+export function listenPendingCandidates(
+  uid: string,
+  cb: (candidates: AcademyCandidate[]) => void,
+): Unsubscribe {
+  const col = collection(db, 'users', uid, 'academyCandidates');
+  const q = query(col, where('status', '==', 'pending'), orderBy('createdAt', 'desc'));
+  return onSnapshot(q, (snap) => {
+    const list: AcademyCandidate[] = snap.docs.map((d) => ({
+      id: d.id,
+      ...(d.data() as Omit<AcademyCandidate, 'id'>),
+    }));
+    cb(list);
+  });
+}
+
+export async function pullNewCandidate(uid: string): Promise<void> {
+  const userRef = doc(db, 'users', uid);
+  const candidates = collection(userRef, 'academyCandidates');
+  const now = new Date();
+  const nextDate = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+  try {
+    await runTransaction(db, async (tx) => {
+      const userSnap = await tx.get(userRef);
+      const data = userSnap.data() as UserDoc;
+      const nextPullAt = data.academy?.nextPullAt?.toDate();
+      if (nextPullAt && nextPullAt > now) {
+        throw new Error('2 saat beklemelisin');
+      }
+      const candidateRef = doc(candidates);
+      tx.set(candidateRef, {
+        status: 'pending',
+        createdAt: serverTimestamp(),
+        player: generateMockCandidate(),
+        source: 'academy',
+      });
+      tx.set(
+        userRef,
+        {
+          academy: {
+            lastPullAt: serverTimestamp(),
+            nextPullAt: Timestamp.fromDate(nextDate),
+          },
+        },
+        { merge: true },
+      );
+    });
+    toast.success('Yeni aday eklendi');
+  } catch (err) {
+    console.warn(err);
+    toast.error((err as Error).message || 'İşlem başarısız');
+    throw err;
+  }
+}
+
+export async function resetCooldownWithDiamonds(uid: string): Promise<void> {
+  const userRef = doc(db, 'users', uid);
+  const now = new Date();
+  try {
+    await runTransaction(db, async (tx) => {
+      const snap = await tx.get(userRef);
+      const data = snap.data() as UserDoc;
+      const balance = data.diamondBalance ?? 0;
+      if (balance < 100) {
+        throw new Error('Yetersiz elmas');
+      }
+      tx.update(userRef, {
+        diamondBalance: increment(-100),
+        'academy.lastPullAt': serverTimestamp(),
+        'academy.nextPullAt': Timestamp.fromDate(now),
+      });
+    });
+    toast.success('Süre sıfırlandı');
+  } catch (err) {
+    console.warn(err);
+    toast.error((err as Error).message || 'İşlem başarısız');
+    throw err;
+  }
+}
+
+export async function acceptCandidate(uid: string, candidateId: string): Promise<void> {
+  const userRef = doc(db, 'users', uid);
+  const candidateRef = doc(userRef, 'academyCandidates', candidateId);
+  const squadRef = doc(userRef, 'squadPending', candidateId);
+  try {
+    await runTransaction(db, async (tx) => {
+      const snap = await tx.get(candidateRef);
+      if (!snap.exists()) {
+        throw new Error('Aday bulunamadı');
+      }
+      const data = snap.data() as { player: CandidatePlayer };
+      tx.set(squadRef, {
+        player: data.player,
+        source: 'academy',
+        createdAt: serverTimestamp(),
+      });
+      tx.delete(candidateRef);
+    });
+    toast.success('Oyuncu takıma eklendi (mock)');
+  } catch (err) {
+    console.warn(err);
+    toast.error('İşlem başarısız');
+    throw err;
+  }
+}
+
+export async function releaseCandidate(uid: string, candidateId: string): Promise<void> {
+  const ref = doc(db, 'users', uid, 'academyCandidates', candidateId);
+  try {
+    await deleteDoc(ref);
+    toast.success('Oyuncu serbest bırakıldı');
+  } catch (err) {
+    console.warn(err);
+    toast.error('İşlem başarısız');
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add academy candidate services and React components
- allow pulling new candidates with 2h cooldown and diamond reset
- include Firestore rules for user subcollections

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a625162554832a82c53a334cac79c4