### PR TITLE
feat: add academy candidate system with cooldown and reset

### DIFF
--- a/src/features/academy/CooldownPanel.tsx
+++ b/src/features/academy/CooldownPanel.tsx
@@ -38,7 +38,7 @@ const CooldownPanel: React.FC<Props> = ({ nextPullAt, onPull, onReset, canReset 
       </Button>
       <Button
         onClick={onReset}
-        disabled={!canReset}
+        disabled={!canReset || canPull}
         variant="secondary"
         data-testid="academy-reset"
       >


### PR DESCRIPTION
## Summary
- persist academy candidates with pull and management transactions
- allow cooldown reset via diamonds and block reset when candidates are available
- expose academy page with live cooldown panel and candidate actions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62826b500832a8ea74340adac4c17