### PR TITLE
feat: add youth academy cooldown

### DIFF
--- a/src/features/academy/CooldownPanel.tsx
+++ b/src/features/academy/CooldownPanel.tsx
@@ -26,7 +26,12 @@ const CooldownPanel: React.FC<Props> = ({ nextPullAt, onPull, onReset, canReset 
   }, [nextPullAt]);
 
   const canPull = remaining === 0;
-  const minutes = Math.floor(remaining / 60000);
+  const hours = Math.floor(remaining / 3600000)
+    .toString()
+    .padStart(2, '0');
+  const minutes = Math.floor((remaining % 3600000) / 60000)
+    .toString()
+    .padStart(2, '0');
   const seconds = Math.floor((remaining % 60000) / 1000)
     .toString()
     .padStart(2, '0');
@@ -46,7 +51,7 @@ const CooldownPanel: React.FC<Props> = ({ nextPullAt, onPull, onReset, canReset 
       </Button>
       {!canPull && (
         <span className="text-sm text-muted-foreground">
-          Kalan: {minutes}:{seconds}
+          Kalan: {hours}:{minutes}:{seconds}
         </span>
       )}
     </div>

--- a/src/services/academy.test.ts
+++ b/src/services/academy.test.ts
@@ -1,17 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
-import { resetCooldownWithDiamonds } from './academy';
+import { resetCooldownWithDiamonds, pullNewCandidate, ACADEMY_COOLDOWN_MS } from './academy';
 
 vi.mock('./firebase', () => ({ db: {} }));
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
-const docMock = vi.fn();
+const docMock = vi.fn(() => ({}));
+const collectionMock = vi.fn(() => ({}));
 const runTransactionMock = vi.fn();
+const fromDateMock = vi.fn();
 
 vi.mock('firebase/firestore', () => ({
   doc: (...args: unknown[]) => docMock(...args),
+  collection: (...args: unknown[]) => collectionMock(...args),
   runTransaction: (...args: unknown[]) => runTransactionMock(...args),
   serverTimestamp: vi.fn(),
-  Timestamp: { fromDate: vi.fn() },
+  Timestamp: { fromDate: (...args: unknown[]) => fromDateMock(...args) },
   increment: vi.fn(),
 }));
 
@@ -24,5 +27,35 @@ describe('resetCooldownWithDiamonds', () => {
       });
     });
     await expect(resetCooldownWithDiamonds('uid')).rejects.toThrow('Yetersiz elmas');
+  });
+});
+
+describe('pullNewCandidate', () => {
+  it('throws if cooldown active', async () => {
+    const future = new Date(Date.now() + 1000);
+    runTransactionMock.mockImplementation(async (_db, fn) => {
+      await fn({
+        get: async () => ({ data: () => ({ academy: { nextPullAt: { toDate: () => future } } }) }),
+        set: vi.fn(),
+      });
+    });
+    await expect(pullNewCandidate('uid')).rejects.toThrow('2 saat beklemelisin');
+  });
+
+  it('sets next pull time 2 hours ahead', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2020-01-01T00:00:00Z'));
+    const setMock = vi.fn();
+    runTransactionMock.mockImplementation(async (_db, fn) => {
+      await fn({
+        get: async () => ({ data: () => ({}) }),
+        set: setMock,
+      });
+    });
+    await pullNewCandidate('uid');
+    expect(fromDateMock).toHaveBeenCalled();
+    const calledDate = fromDateMock.mock.calls[0][0] as Date;
+    expect(calledDate.getTime()).toBe(Date.now() + ACADEMY_COOLDOWN_MS);
+    vi.useRealTimers();
   });
 });

--- a/src/services/academy.ts
+++ b/src/services/academy.ts
@@ -16,6 +16,8 @@ import { db } from './firebase';
 import { toast } from 'sonner';
 import { generateMockCandidate, CandidatePlayer } from '@/features/academy/generateMockCandidate';
 
+export const ACADEMY_COOLDOWN_MS = 2 * 60 * 60 * 1000; // 2 saat
+
 interface UserDoc {
   diamondBalance?: number;
   academy?: {
@@ -50,7 +52,7 @@ export async function pullNewCandidate(uid: string): Promise<void> {
   const userRef = doc(db, 'users', uid);
   const candidates = collection(userRef, 'academyCandidates');
   const now = new Date();
-  const nextDate = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+  const nextDate = new Date(now.getTime() + ACADEMY_COOLDOWN_MS);
   try {
     await runTransaction(db, async (tx) => {
       const userSnap = await tx.get(userRef);


### PR DESCRIPTION
## Summary
- enforce two-hour cooldown after generating academy players
- allow diamond reset and display hours in cooldown panel
- test academy cooldown logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a772de17dc832ab61b0a00c8135818