### PR TITLE
Show academy candidate card after generation

### DIFF
--- a/src/features/academy/AcademyPage.tsx
+++ b/src/features/academy/AcademyPage.tsx
@@ -61,7 +61,10 @@ const AcademyPage = () => {
   const handlePull = async () => {
     if (user) {
       try {
-        await pullNewCandidate(user.id);
+        const candidate = await pullNewCandidate(user.id);
+        // optimistically show the new candidate before Firestore listener updates
+        setCandidates((prev) => [candidate, ...prev]);
+        setNextPullAt(new Date(Date.now() + ACADEMY_COOLDOWN_MS));
         return;
       } catch (err) {
         console.warn(err);

--- a/src/services/academy.test.ts
+++ b/src/services/academy.test.ts
@@ -54,7 +54,9 @@ describe('pullNewCandidate', () => {
     });
     await pullNewCandidate('uid');
     expect(fromDateMock).toHaveBeenCalled();
-    const calledDate = fromDateMock.mock.calls[0][0] as Date;
+    // Use the last call which reflects the cooldown timestamp
+    const calls = fromDateMock.mock.calls;
+    const calledDate = calls[calls.length - 1][0] as Date;
     expect(calledDate.getTime()).toBe(Date.now() + ACADEMY_COOLDOWN_MS);
     vi.useRealTimers();
   });


### PR DESCRIPTION
## Summary
- Return new candidate from `pullNewCandidate` so the UI can use it immediately
- Optimistically add the candidate card and update cooldown in `AcademyPage`
- Adjust academy service test for updated behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b641f3f4832aa2af979dc7c0ef66