### PR TITLE
Persist youth candidates and update list on release

### DIFF
--- a/src/features/academy/AcademyPage.tsx
+++ b/src/features/academy/AcademyPage.tsx
@@ -7,6 +7,8 @@ import {
   listenPendingCandidates,
   pullNewCandidate,
   resetCooldownWithDiamonds,
+  acceptCandidate,
+  releaseCandidate,
   AcademyCandidate,
   ACADEMY_COOLDOWN_MS,
 } from '@/services/academy';
@@ -93,6 +95,26 @@ const AcademyPage = () => {
     setNextPullAt(new Date());
   };
 
+  const handleAccept = async (id: string) => {
+    if (!user) return;
+    try {
+      await acceptCandidate(user.id, id);
+      setCandidates((prev) => prev.filter((c) => c.id !== id));
+    } catch (err) {
+      console.warn(err);
+    }
+  };
+
+  const handleRelease = async (id: string) => {
+    if (!user) return;
+    try {
+      await releaseCandidate(user.id, id);
+      setCandidates((prev) => prev.filter((c) => c.id !== id));
+    } catch (err) {
+      console.warn(err);
+    }
+  };
+
   if (!user) {
     return <div className="p-4">Giriş yapmalısın</div>;
   }
@@ -140,7 +162,11 @@ const AcademyPage = () => {
         canReset={balance >= 100}
       />
       <h2 className="text-xl font-semibold">Genç Oyuncular</h2>
-      <CandidatesList candidates={candidates} />
+      <CandidatesList
+        candidates={candidates}
+        onAccept={handleAccept}
+        onRelease={handleRelease}
+      />
     </div>
   );
 };

--- a/src/features/academy/CandidateCard.tsx
+++ b/src/features/academy/CandidateCard.tsx
@@ -1,4 +1,4 @@
-import { AcademyCandidate, acceptCandidate, releaseCandidate } from '@/services/academy';
+import { AcademyCandidate } from '@/services/academy';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { StatBar } from '@/components/ui/stat-bar';
@@ -10,33 +10,15 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useAuth } from '@/contexts/AuthContext';
 
 interface Props {
   candidate: AcademyCandidate;
+  onAccept: (id: string) => void;
+  onRelease: (id: string) => void;
 }
 
-const CandidateCard: React.FC<Props> = ({ candidate }) => {
+const CandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease }) => {
   const { player } = candidate;
-  const { user } = useAuth();
-
-  const handleAccept = async () => {
-    if (!user) return;
-    try {
-      await acceptCandidate(user.id, candidate.id);
-    } catch (err) {
-      console.warn(err);
-    }
-  };
-
-  const handleRelease = async () => {
-    if (!user) return;
-    try {
-      await releaseCandidate(user.id, candidate.id);
-    } catch (err) {
-      console.warn(err);
-    }
-  };
   const initials = player.name
     .split(' ')
     .map((n) => n[0])
@@ -78,8 +60,12 @@ const CandidateCard: React.FC<Props> = ({ candidate }) => {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={handleAccept}>Takıma Al</DropdownMenuItem>
-                <DropdownMenuItem onClick={handleRelease}>Serbest Bırak</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onAccept(candidate.id)}>
+                  Takıma Al
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onRelease(candidate.id)}>
+                  Serbest Bırak
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>

--- a/src/features/academy/CandidatesList.tsx
+++ b/src/features/academy/CandidatesList.tsx
@@ -3,16 +3,23 @@ import { AcademyCandidate } from '@/services/academy';
 
 interface Props {
   candidates: AcademyCandidate[];
+  onAccept: (id: string) => void;
+  onRelease: (id: string) => void;
 }
 
-const CandidatesList: React.FC<Props> = ({ candidates }) => {
+const CandidatesList: React.FC<Props> = ({ candidates, onAccept, onRelease }) => {
   if (candidates.length === 0) {
     return <p className="text-sm text-muted-foreground">Henüz aday yok</p>;
   }
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
       {candidates.map((c) => (
-        <CandidateCard key={c.id} candidate={c} />
+        <CandidateCard
+          key={c.id}
+          candidate={c}
+          onAccept={onAccept}
+          onRelease={onRelease}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- hook up candidate actions to Firestore so accepted or released youth players update immediately
- update candidate list to accept callbacks for accepting or releasing players
- remove released candidates from UI list instantly for better persistence

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8c3bc9f38832abf25cc491c9d347b