### PR TITLE
Persist youth candidates in Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,6 +3,9 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /users/{uid} {
       allow read, write: if request.auth != null && request.auth.uid == uid;
+      match /youthCandidates/{candidateId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
       match /{document=**} {
         allow read, write: if request.auth != null && request.auth.uid == uid;
       }

--- a/src/features/youth/YouthCandidateCard.tsx
+++ b/src/features/youth/YouthCandidateCard.tsx
@@ -1,0 +1,78 @@
+import { YouthCandidate } from '@/services/youth';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { StatBar } from '@/components/ui/stat-bar';
+import { Button } from '@/components/ui/button';
+import { TrendingUp } from 'lucide-react';
+
+interface Props {
+  candidate: YouthCandidate;
+  onAccept: (id: string) => void;
+  onRelease: (id: string) => void;
+}
+
+const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease }) => {
+  const { player } = candidate;
+  const initials = player.name
+    .split(' ')
+    .map((n) => n[0])
+    .join('');
+
+  return (
+    <Card
+      data-testid={`youth-candidate-${candidate.id}`}
+      className="p-4 hover:shadow-md transition-shadow"
+    >
+      <div className="flex items-start gap-3">
+        <div className="relative">
+          <div className="w-12 h-12 bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-800 rounded-full flex items-center justify-center text-lg font-semibold">
+            {initials}
+          </div>
+          <div className="absolute -bottom-1 -right-1 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold text-white bg-gray-500">
+            {player.position}
+          </div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between mb-2">
+            <div>
+              <h3 className="font-semibold text-sm truncate">{player.name}</h3>
+              <div className="flex items-center gap-2 mt-1">
+                <Badge variant="secondary" className="text-xs">
+                  {player.age} yaş
+                </Badge>
+                <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <TrendingUp className="w-3 h-3" />
+                  <span className="font-semibold">{player.overall.toFixed(3)}</span>
+                </div>
+              </div>
+            </div>
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onAccept(candidate.id)}
+                data-testid={`youth-accept-${candidate.id}`}
+              >
+                Takıma Al
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onRelease(candidate.id)}
+                data-testid={`youth-release-${candidate.id}`}
+              >
+                Serbest Bırak
+              </Button>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <StatBar label="Hız" value={player.attributes.topSpeed} />
+            <StatBar label="Şut" value={player.attributes.shooting} />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default YouthCandidateCard;

--- a/src/features/youth/YouthList.tsx
+++ b/src/features/youth/YouthList.tsx
@@ -1,0 +1,32 @@
+import YouthCandidateCard from './YouthCandidateCard';
+import { YouthCandidate } from '@/services/youth';
+
+interface Props {
+  candidates: YouthCandidate[];
+  onAccept: (id: string) => void;
+  onRelease: (id: string) => void;
+}
+
+const YouthList: React.FC<Props> = ({ candidates, onAccept, onRelease }) => {
+  if (candidates.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Henüz altyapı oyuncusu yok. Yeni aday üret.
+      </p>
+    );
+  }
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {candidates.map((c) => (
+        <YouthCandidateCard
+          key={c.id}
+          candidate={c}
+          onAccept={onAccept}
+          onRelease={onRelease}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default YouthList;

--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { toast } from 'sonner';
+import {
+  listenYouthCandidates,
+  createYouthCandidate,
+  acceptYouthCandidate,
+  releaseYouthCandidate,
+  YouthCandidate,
+} from '@/services/youth';
+import { generateRandomName } from '@/lib/names';
+import { Button } from '@/components/ui/button';
+import YouthList from './YouthList';
+import type { Player } from '@/types';
+
+const positions: Player['position'][] = ['GK','CB','LB','RB','CM','LM','RM','CAM','LW','RW','ST'];
+const randomAttr = () => parseFloat(Math.random().toFixed(3));
+const generatePlayer = (): Player => ({
+  id: crypto.randomUUID(),
+  name: generateRandomName(),
+  position: positions[Math.floor(Math.random() * positions.length)],
+  overall: randomAttr(),
+  attributes: {
+    strength: randomAttr(),
+    acceleration: randomAttr(),
+    topSpeed: randomAttr(),
+    dribbleSpeed: randomAttr(),
+    jump: randomAttr(),
+    tackling: randomAttr(),
+    ballKeeping: randomAttr(),
+    passing: randomAttr(),
+    longBall: randomAttr(),
+    agility: randomAttr(),
+    shooting: randomAttr(),
+    shootPower: randomAttr(),
+    positioning: randomAttr(),
+    reaction: randomAttr(),
+    ballControl: randomAttr(),
+  },
+  age: Math.floor(Math.random() * 5) + 16,
+  height: 180,
+  weight: 75,
+  squadRole: 'youth',
+});
+
+const YouthPage = () => {
+  const { user } = useAuth();
+  const [candidates, setCandidates] = useState<YouthCandidate[]>([]);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    return listenYouthCandidates(user.id, setCandidates);
+  }, [user?.id]);
+
+  const handleGenerate = async () => {
+    if (!user?.id) return;
+    try {
+      const player = generatePlayer();
+      await createYouthCandidate(user.id, player);
+      toast.success('Oyuncu üretildi');
+    } catch (err) {
+      console.warn(err);
+      toast.error('İşlem başarısız');
+    }
+  };
+
+  const handleAccept = async (id: string) => {
+    if (!user?.id) return;
+    try {
+      await acceptYouthCandidate(user.id, id);
+      toast.success('Oyuncu takıma eklendi');
+    } catch (err) {
+      console.warn(err);
+      toast.error('İşlem başarısız');
+    }
+  };
+
+  const handleRelease = async (id: string) => {
+    if (!user?.id) return;
+    try {
+      await releaseYouthCandidate(user.id, id);
+      toast.success('Oyuncu serbest bırakıldı');
+    } catch (err) {
+      console.warn(err);
+      toast.error('İşlem başarısız');
+    }
+  };
+
+  if (!user) {
+    return <div className="p-4">Giriş yapmalısın</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Altyapı</h1>
+        <Button onClick={handleGenerate} data-testid="youth-generate">
+          Oyuncu Üret
+        </Button>
+      </div>
+      <YouthList
+        candidates={candidates}
+        onAccept={handleAccept}
+        onRelease={handleRelease}
+      />
+    </div>
+  );
+};
+
+export default YouthPage;

--- a/src/pages/Youth.tsx
+++ b/src/pages/Youth.tsx
@@ -1,6 +1,6 @@
-import AcademyPage from '@/features/academy/AcademyPage';
+import YouthPage from '@/features/youth/YouthPage';
 
 export default function Youth() {
-  return <AcademyPage />;
+  return <YouthPage />;
 }
 

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, enableIndexedDbPersistence } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -17,4 +17,5 @@ console.log(
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+enableIndexedDbPersistence(db).catch(() => {});
 

--- a/src/services/youth.ts
+++ b/src/services/youth.ts
@@ -1,0 +1,68 @@
+import {
+  collection,
+  addDoc,
+  onSnapshot,
+  query,
+  where,
+  orderBy,
+  doc,
+  getDoc,
+  deleteDoc,
+  Unsubscribe,
+  serverTimestamp,
+  Timestamp,
+} from 'firebase/firestore';
+import { db } from './firebase';
+import { Player } from '@/types';
+import { addPlayerToTeam } from './team';
+
+export type YouthCandidate = {
+  id: string;
+  status: 'pending';
+  createdAt: Timestamp;
+  player: Player;
+};
+
+export function listenYouthCandidates(
+  uid: string,
+  cb: (list: YouthCandidate[]) => void,
+): Unsubscribe {
+  const col = collection(db, 'users', uid, 'youthCandidates');
+  const q = query(col, where('status', '==', 'pending'), orderBy('createdAt', 'desc'));
+  return onSnapshot(q, (snap) => {
+    const list: YouthCandidate[] = snap.docs.map((d) => ({
+      id: d.id,
+      ...(d.data() as Omit<YouthCandidate, 'id'>),
+    }));
+    cb(list);
+  });
+}
+
+export async function createYouthCandidate(uid: string, player: Player): Promise<void> {
+  const col = collection(db, 'users', uid, 'youthCandidates');
+  await addDoc(col, {
+    status: 'pending',
+    createdAt: serverTimestamp(),
+    player,
+  });
+}
+
+export async function acceptYouthCandidate(
+  uid: string,
+  candidateId: string,
+): Promise<void> {
+  const ref = doc(db, 'users', uid, 'youthCandidates', candidateId);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return;
+  const data = snap.data() as { player: Player };
+  await addPlayerToTeam(uid, data.player);
+  await deleteDoc(ref);
+}
+
+export async function releaseYouthCandidate(
+  uid: string,
+  candidateId: string,
+): Promise<void> {
+  const ref = doc(db, 'users', uid, 'youthCandidates', candidateId);
+  await deleteDoc(ref);
+}


### PR DESCRIPTION
## Summary
- enable Firestore indexedDB persistence for offline data
- add youth candidate service and Firestore-backed youth feature components
- allow authenticated users to manage youthCandidates in Firestore rules

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8cdda5f4c832aa00d6acef3d33a71