### PR TITLE
Render youth candidate card immediately

### DIFF
--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -56,7 +56,8 @@ const YouthPage = () => {
     if (!user?.id) return;
     try {
       const player = generatePlayer();
-      await createYouthCandidate(user.id, player);
+      const candidate = await createYouthCandidate(user.id, player);
+      setCandidates((prev) => [candidate, ...prev]);
       toast.success('Oyuncu üretildi');
     } catch (err) {
       console.warn(err);

--- a/src/services/youth.ts
+++ b/src/services/youth.ts
@@ -38,13 +38,22 @@ export function listenYouthCandidates(
   });
 }
 
-export async function createYouthCandidate(uid: string, player: Player): Promise<void> {
+export async function createYouthCandidate(
+  uid: string,
+  player: Player,
+): Promise<YouthCandidate> {
   const col = collection(db, 'users', uid, 'youthCandidates');
-  await addDoc(col, {
+  const ref = await addDoc(col, {
     status: 'pending',
     createdAt: serverTimestamp(),
     player,
   });
+  return {
+    id: ref.id,
+    status: 'pending',
+    createdAt: Timestamp.now(),
+    player,
+  };
 }
 
 export async function acceptYouthCandidate(


### PR DESCRIPTION
## Summary
- return newly created youth candidate from service
- update state after generation to show candidate card without refresh

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9e9d76120832a9a42591694f9f932