### PR TITLE
Remove youth player cards instantly after action

### DIFF
--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -69,6 +69,7 @@ const YouthPage = () => {
     if (!user?.id) return;
     try {
       await acceptYouthCandidate(user.id, id);
+      setCandidates((prev) => prev.filter((c) => c.id !== id));
       toast.success('Oyuncu takıma eklendi');
     } catch (err) {
       console.warn(err);
@@ -80,6 +81,7 @@ const YouthPage = () => {
     if (!user?.id) return;
     try {
       await releaseYouthCandidate(user.id, id);
+      setCandidates((prev) => prev.filter((c) => c.id !== id));
       toast.success('Oyuncu serbest bırakıldı');
     } catch (err) {
       console.warn(err);


### PR DESCRIPTION
## Summary
- remove youth candidate card from UI immediately after accepting or releasing

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9ebb9ee04832a89c2171da19100a1