### PR TITLE
feat: add youth cooldown with diamond reset

### DIFF
--- a/src/features/youth/CooldownPanel.tsx
+++ b/src/features/youth/CooldownPanel.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { YOUTH_COOLDOWN_MS } from '@/services/youth';
+
+interface Props {
+  nextGenerateAt: Date | null;
+  onReset: () => void;
+  canReset: boolean;
+}
+
+const CooldownPanel: React.FC<Props> = ({ nextGenerateAt, onReset, canReset }) => {
+  const [remaining, setRemaining] = useState(0);
+
+  useEffect(() => {
+    const tick = () => {
+      if (!nextGenerateAt) {
+        setRemaining(0);
+        return;
+      }
+      const diff = nextGenerateAt.getTime() - Date.now();
+      setRemaining(diff > 0 ? diff : 0);
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [nextGenerateAt]);
+
+  const progress = YOUTH_COOLDOWN_MS
+    ? ((YOUTH_COOLDOWN_MS - remaining) / YOUTH_COOLDOWN_MS) * 100
+    : 100;
+
+  const hours = Math.floor(remaining / 3600000).toString().padStart(2, '0');
+  const minutes = Math.floor((remaining % 3600000) / 60000)
+    .toString()
+    .padStart(2, '0');
+  const seconds = Math.floor((remaining % 60000) / 1000)
+    .toString()
+    .padStart(2, '0');
+
+  const canGenerate = remaining === 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Oyuncu Üretimi</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Progress value={progress} className="h-2" />
+        <div className="flex items-center justify-between text-sm">
+          <span>
+            Sonraki üretim: {hours}:{minutes}:{seconds}
+          </span>
+          <Button
+            onClick={onReset}
+            disabled={!canReset || canGenerate}
+            size="sm"
+            variant="secondary"
+            data-testid="youth-reset"
+          >
+            Hızlandır (💎5)
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CooldownPanel;
+

--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
 import { useAuth } from '@/contexts/AuthContext';
+import { useDiamonds } from '@/contexts/DiamondContext';
 import { toast } from 'sonner';
 import {
   listenYouthCandidates,
   createYouthCandidate,
   acceptYouthCandidate,
   releaseYouthCandidate,
+  resetCooldownWithDiamonds,
   YouthCandidate,
+  YOUTH_COOLDOWN_MS,
 } from '@/services/youth';
+import { db } from '@/services/firebase';
 import { generateRandomName } from '@/lib/names';
 import { Button } from '@/components/ui/button';
 import YouthList from './YouthList';
+import CooldownPanel from './CooldownPanel';
 import type { Player } from '@/types';
 
 const positions: Player['position'][] = ['GK','CB','LB','RB','CM','LM','RM','CAM','LW','RW','ST'];
@@ -45,12 +51,42 @@ const generatePlayer = (): Player => ({
 
 const YouthPage = () => {
   const { user } = useAuth();
+  const { balance } = useDiamonds();
   const [candidates, setCandidates] = useState<YouthCandidate[]>([]);
+  const [nextGenerateAt, setNextGenerateAt] = useState<Date | null>(null);
+  const [canGenerate, setCanGenerate] = useState(false);
 
   useEffect(() => {
     if (!user?.id) return;
     return listenYouthCandidates(user.id, setCandidates);
   }, [user?.id]);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    try {
+      const ref = doc(db, 'users', user.id);
+      return onSnapshot(ref, (snap) => {
+        const data = snap.data() as { youth?: { nextGenerateAt?: { toDate: () => Date } } } | undefined;
+        const ts = data?.youth?.nextGenerateAt;
+        setNextGenerateAt(ts ? ts.toDate() : null);
+      });
+    } catch (err) {
+      console.warn(err);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    const check = () => {
+      if (!nextGenerateAt) {
+        setCanGenerate(true);
+        return;
+      }
+      setCanGenerate(nextGenerateAt.getTime() <= Date.now());
+    };
+    check();
+    const id = setInterval(check, 1000);
+    return () => clearInterval(id);
+  }, [nextGenerateAt]);
 
   const handleGenerate = async () => {
     if (!user?.id) return;
@@ -58,10 +94,20 @@ const YouthPage = () => {
       const player = generatePlayer();
       const candidate = await createYouthCandidate(user.id, player);
       setCandidates((prev) => [candidate, ...prev]);
+      setNextGenerateAt(new Date(Date.now() + YOUTH_COOLDOWN_MS));
       toast.success('Oyuncu üretildi');
     } catch (err) {
       console.warn(err);
-      toast.error('İşlem başarısız');
+      toast.error((err as Error).message || 'İşlem başarısız');
+    }
+  };
+
+  const handleReset = async () => {
+    if (!user?.id) return;
+    try {
+      await resetCooldownWithDiamonds(user.id);
+    } catch (err) {
+      console.warn(err);
     }
   };
 
@@ -97,10 +143,15 @@ const YouthPage = () => {
     <div className="p-4 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Altyapı</h1>
-        <Button onClick={handleGenerate} data-testid="youth-generate">
+        <Button onClick={handleGenerate} disabled={!canGenerate} data-testid="youth-generate">
           Oyuncu Üret
         </Button>
       </div>
+      <CooldownPanel
+        nextGenerateAt={nextGenerateAt}
+        onReset={handleReset}
+        canReset={balance >= 100}
+      />
       <YouthList
         candidates={candidates}
         onAccept={handleAccept}

--- a/src/services/youth.test.ts
+++ b/src/services/youth.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createYouthCandidate,
+  resetCooldownWithDiamonds,
+  YOUTH_COOLDOWN_MS,
+} from './youth';
+import type { Player } from '@/types';
+
+vi.mock('./firebase', () => ({ db: {} }));
+
+const docMock = vi.fn(() => ({ id: 'id' }));
+const collectionMock = vi.fn(() => ({}));
+const runTransactionMock = vi.fn();
+const fromDateMock = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: unknown[]) => docMock(...args),
+  collection: (...args: unknown[]) => collectionMock(...args),
+  runTransaction: (...args: unknown[]) => runTransactionMock(...args),
+  serverTimestamp: vi.fn(),
+  Timestamp: { fromDate: (...args: unknown[]) => fromDateMock(...args) },
+  increment: vi.fn(),
+}));
+
+const player: Player = {
+  id: 'p1',
+  name: 'Test',
+  position: 'GK',
+  overall: 0.5,
+  attributes: {
+    strength: 0,
+    acceleration: 0,
+    topSpeed: 0,
+    dribbleSpeed: 0,
+    jump: 0,
+    tackling: 0,
+    ballKeeping: 0,
+    passing: 0,
+    longBall: 0,
+    agility: 0,
+    shooting: 0,
+    shootPower: 0,
+    positioning: 0,
+    reaction: 0,
+    ballControl: 0,
+  },
+  age: 16,
+  height: 180,
+  weight: 70,
+  squadRole: 'youth',
+};
+
+describe('resetCooldownWithDiamonds', () => {
+  it('throws when not enough diamonds', async () => {
+    runTransactionMock.mockImplementation(async (_db, fn) => {
+      await fn({
+        get: async () => ({ data: () => ({ diamondBalance: 50 }) }),
+        update: vi.fn(),
+      });
+    });
+    await expect(resetCooldownWithDiamonds('uid')).rejects.toThrow('Yetersiz elmas');
+  });
+});
+
+describe('createYouthCandidate', () => {
+  it('throws if cooldown active', async () => {
+    const future = new Date(Date.now() + 1000);
+    runTransactionMock.mockImplementation(async (_db, fn) => {
+      await fn({
+        get: async () => ({ data: () => ({ youth: { nextGenerateAt: { toDate: () => future } } }) }),
+        set: vi.fn(),
+      });
+    });
+    await expect(createYouthCandidate('uid', player)).rejects.toThrow('2 saat beklemelisin');
+  });
+
+  it('sets next generate time 2 hours ahead', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2020-01-01T00:00:00Z'));
+    const setMock = vi.fn();
+    runTransactionMock.mockImplementation(async (_db, fn) => {
+      await fn({
+        get: async () => ({ data: () => ({}) }),
+        set: setMock,
+      });
+    });
+    await createYouthCandidate('uid', player);
+    expect(fromDateMock).toHaveBeenCalled();
+    const calls = fromDateMock.mock.calls;
+    const calledDate = calls[0][0] as Date;
+    expect(calledDate.getTime()).toBe(Date.now() + YOUTH_COOLDOWN_MS);
+    vi.useRealTimers();
+  });
+});
+


### PR DESCRIPTION
## Summary
- enforce 2-hour cooldown on youth player generation
- allow spending diamonds to reset cooldown
- show cooldown timer with diamond fast-forward

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ed2aff64832abac309a959abc11f