### PR TITLE
feat: add player roles and position-based overall

### DIFF
--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/services/youth';
 import { db } from '@/services/firebase';
 import { generateRandomName } from '@/lib/names';
+import { calculateOverall, getRoles } from '@/lib/player';
 import { Button } from '@/components/ui/button';
 import YouthList from './YouthList';
 import CooldownPanel from './CooldownPanel';
@@ -21,12 +22,9 @@ import type { Player } from '@/types';
 
 const positions: Player['position'][] = ['GK','CB','LB','RB','CM','LM','RM','CAM','LW','RW','ST'];
 const randomAttr = () => parseFloat(Math.random().toFixed(3));
-const generatePlayer = (): Player => ({
-  id: crypto.randomUUID(),
-  name: generateRandomName(),
-  position: positions[Math.floor(Math.random() * positions.length)],
-  overall: randomAttr(),
-  attributes: {
+const generatePlayer = (): Player => {
+  const position = positions[Math.floor(Math.random() * positions.length)];
+  const attributes = {
     strength: randomAttr(),
     acceleration: randomAttr(),
     topSpeed: randomAttr(),
@@ -42,12 +40,20 @@ const generatePlayer = (): Player => ({
     positioning: randomAttr(),
     reaction: randomAttr(),
     ballControl: randomAttr(),
-  },
-  age: Math.floor(Math.random() * 5) + 16,
-  height: 180,
-  weight: 75,
-  squadRole: 'youth',
-});
+  } as Player['attributes'];
+  return {
+    id: crypto.randomUUID(),
+    name: generateRandomName(),
+    position,
+    roles: getRoles(position),
+    overall: calculateOverall(position, attributes),
+    attributes,
+    age: Math.floor(Math.random() * 5) + 16,
+    height: 180,
+    weight: 75,
+    squadRole: 'youth',
+  };
+};
 
 const YouthPage = () => {
   const { user } = useAuth();

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,5 @@
 import { Player, Match, Team, Training, FinanceRecord } from '@/types';
+import { getRoles } from './player';
 
 const createAttributes = (attrs: Partial<Player['attributes']>): Player['attributes'] => ({
   strength: 0.5,
@@ -26,6 +27,7 @@ export const mockPlayers: Player[] = [
     id: '1',
     name: 'Mehmet Özkan',
     position: 'GK',
+    roles: getRoles('GK'),
     overall: 0.852,
     attributes: createAttributes({
       topSpeed: 0.432,
@@ -45,6 +47,7 @@ export const mockPlayers: Player[] = [
     id: '2',
     name: 'Ali Yılmaz',
     position: 'CB',
+    roles: getRoles('CB'),
     overall: 0.789,
     attributes: createAttributes({
       topSpeed: 0.567,
@@ -64,6 +67,7 @@ export const mockPlayers: Player[] = [
     id: '3',
     name: 'Can Demir',
     position: 'CB',
+    roles: getRoles('CB'),
     overall: 0.776,
     attributes: createAttributes({
       topSpeed: 0.534,
@@ -83,6 +87,7 @@ export const mockPlayers: Player[] = [
     id: '4',
     name: 'Emre Kara',
     position: 'LB',
+    roles: getRoles('LB'),
     overall: 0.723,
     attributes: createAttributes({
       topSpeed: 0.789,
@@ -102,6 +107,7 @@ export const mockPlayers: Player[] = [
     id: '5',
     name: 'Burak Şen',
     position: 'RB',
+    roles: getRoles('RB'),
     overall: 0.734,
     attributes: createAttributes({
       topSpeed: 0.798,
@@ -121,6 +127,7 @@ export const mockPlayers: Player[] = [
     id: '6',
     name: 'Oğuz Çelik',
     position: 'CM',
+    roles: getRoles('CM'),
     overall: 0.812,
     attributes: createAttributes({
       topSpeed: 0.656,
@@ -140,6 +147,7 @@ export const mockPlayers: Player[] = [
     id: '7',
     name: 'Serkan Aydın',
     position: 'CM',
+    roles: getRoles('CM'),
     overall: 0.798,
     attributes: createAttributes({
       topSpeed: 0.645,
@@ -159,6 +167,7 @@ export const mockPlayers: Player[] = [
     id: '8',
     name: 'Kemal Arslan',
     position: 'LW',
+    roles: getRoles('LW'),
     overall: 0.845,
     attributes: createAttributes({
       topSpeed: 0.923,
@@ -178,6 +187,7 @@ export const mockPlayers: Player[] = [
     id: '9',
     name: 'Hakan Polat',
     position: 'RW',
+    roles: getRoles('RW'),
     overall: 0.834,
     attributes: createAttributes({
       topSpeed: 0.912,
@@ -197,6 +207,7 @@ export const mockPlayers: Player[] = [
     id: '10',
     name: 'Murat Koç',
     position: 'CAM',
+    roles: getRoles('CAM'),
     overall: 0.867,
     attributes: createAttributes({
       topSpeed: 0.734,
@@ -216,6 +227,7 @@ export const mockPlayers: Player[] = [
     id: '11',
     name: 'Volkan Tekin',
     position: 'ST',
+    roles: getRoles('ST'),
     overall: 0.889,
     attributes: createAttributes({
       topSpeed: 0.823,
@@ -235,6 +247,7 @@ export const mockPlayers: Player[] = [
     id: '12',
     name: 'Yusuf Balık',
     position: 'GK',
+    roles: getRoles('GK'),
     overall: 0.678,
     attributes: createAttributes({
       topSpeed: 0.345,
@@ -254,6 +267,7 @@ export const mockPlayers: Player[] = [
     id: '13',
     name: 'Fatih Güven',
     position: 'CB',
+    roles: getRoles('CB'),
     overall: 0.634,
     attributes: createAttributes({
       topSpeed: 0.456,
@@ -273,6 +287,7 @@ export const mockPlayers: Player[] = [
     id: '14',
     name: 'Deniz Akın',
     position: 'CM',
+    roles: getRoles('CM'),
     overall: 0.687,
     attributes: createAttributes({
       topSpeed: 0.567,
@@ -295,6 +310,7 @@ export const youthPlayers: Player[] = [
     id: 'y1',
     name: 'Ahmet Genç',
     position: 'ST',
+    roles: getRoles('ST'),
     overall: 0.567,
     attributes: createAttributes({
       topSpeed: 0.712,
@@ -314,6 +330,7 @@ export const youthPlayers: Player[] = [
     id: 'y2',
     name: 'Berkay Yeni',
     position: 'CM',
+    roles: getRoles('CM'),
     overall: 0.523,
     attributes: createAttributes({
       topSpeed: 0.578,

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -1,0 +1,39 @@
+import type { Player } from '@/types';
+
+const POSITION_ATTRIBUTES: Record<Player['position'], (keyof Player['attributes'])[]> = {
+  GK: ['positioning', 'reaction', 'longBall', 'strength', 'jump'],
+  CB: ['strength', 'tackling', 'jump', 'positioning', 'reaction'],
+  LB: ['acceleration', 'topSpeed', 'tackling', 'passing', 'agility'],
+  RB: ['acceleration', 'topSpeed', 'tackling', 'passing', 'agility'],
+  CM: ['passing', 'ballControl', 'ballKeeping', 'agility', 'reaction'],
+  LM: ['acceleration', 'topSpeed', 'dribbleSpeed', 'passing', 'ballControl'],
+  RM: ['acceleration', 'topSpeed', 'dribbleSpeed', 'passing', 'ballControl'],
+  CAM: ['passing', 'ballControl', 'shooting', 'agility', 'reaction'],
+  LW: ['topSpeed', 'dribbleSpeed', 'shooting', 'ballControl', 'passing'],
+  RW: ['topSpeed', 'dribbleSpeed', 'shooting', 'ballControl', 'passing'],
+  ST: ['shooting', 'shootPower', 'positioning', 'strength', 'topSpeed'],
+};
+
+export function calculateOverall(position: Player['position'], attributes: Player['attributes']): number {
+  const keys = POSITION_ATTRIBUTES[position];
+  const total = keys.reduce((sum, key) => sum + attributes[key], 0);
+  return parseFloat((total / keys.length).toFixed(3));
+}
+
+const POSITION_ROLES: Record<Player['position'], Player['position'][]> = {
+  GK: ['GK'],
+  CB: ['CB'],
+  LB: ['LB', 'LM'],
+  RB: ['RB', 'RM'],
+  CM: ['CM', 'CAM'],
+  LM: ['LM', 'LW'],
+  RM: ['RM', 'RW'],
+  CAM: ['CAM', 'CM'],
+  LW: ['LW', 'LM', 'ST'],
+  RW: ['RW', 'RM', 'ST'],
+  ST: ['ST', 'CAM'],
+};
+
+export function getRoles(position: Player['position']): Player['position'][] {
+  return POSITION_ROLES[position] || [position];
+}

--- a/src/services/academy.ts
+++ b/src/services/academy.ts
@@ -18,6 +18,7 @@ import { toast } from 'sonner';
 import { generateMockCandidate, CandidatePlayer } from '@/features/academy/generateMockCandidate';
 import { addPlayerToTeam } from './team';
 import type { Player } from '@/types';
+import { calculateOverall, getRoles } from '@/lib/player';
 
 export const ACADEMY_COOLDOWN_MS = 2 * 60 * 60 * 1000; // 2 saat
 
@@ -137,28 +138,31 @@ function mapPosition(pos: string): Player['position'] {
 
 function candidateToPlayer(id: string, c: CandidatePlayer): Player {
   const randomAttr = () => parseFloat(Math.random().toFixed(3));
+  const position = mapPosition(c.position);
+  const attributes: Player['attributes'] = {
+    strength: randomAttr(),
+    acceleration: randomAttr(),
+    topSpeed: c.attributes.topSpeed,
+    dribbleSpeed: randomAttr(),
+    jump: randomAttr(),
+    tackling: randomAttr(),
+    ballKeeping: randomAttr(),
+    passing: randomAttr(),
+    longBall: randomAttr(),
+    agility: randomAttr(),
+    shooting: c.attributes.shooting,
+    shootPower: randomAttr(),
+    positioning: randomAttr(),
+    reaction: randomAttr(),
+    ballControl: randomAttr(),
+  };
   return {
     id,
     name: c.name,
-    position: mapPosition(c.position),
-    overall: c.overall,
-    attributes: {
-      strength: randomAttr(),
-      acceleration: randomAttr(),
-      topSpeed: c.attributes.topSpeed,
-      dribbleSpeed: randomAttr(),
-      jump: randomAttr(),
-      tackling: randomAttr(),
-      ballKeeping: randomAttr(),
-      passing: randomAttr(),
-      longBall: randomAttr(),
-      agility: randomAttr(),
-      shooting: c.attributes.shooting,
-      shootPower: randomAttr(),
-      positioning: randomAttr(),
-      reaction: randomAttr(),
-      ballControl: randomAttr(),
-    },
+    position,
+    roles: getRoles(position),
+    overall: calculateOverall(position, attributes),
+    attributes,
     age: c.age,
     height: 180,
     weight: 75,

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -2,17 +2,15 @@ import { doc, setDoc, getDoc } from 'firebase/firestore';
 import { db } from '@/services/firebase';
 import { Player, ClubTeam } from '@/types';
 import { generateRandomName } from '@/lib/names';
+import { calculateOverall, getRoles } from '@/lib/player';
 
 const positions: Player['position'][] = ['GK','CB','LB','RB','CM','LM','RM','CAM','LW','RW','ST'];
 
 const randomAttr = () => parseFloat(Math.random().toFixed(3));
 
-const generatePlayer = (id: number): Player => ({
-  id: String(id),
-  name: generateRandomName(),
-  position: positions[Math.floor(Math.random() * positions.length)],
-  overall: randomAttr(),
-  attributes: {
+const generatePlayer = (id: number): Player => {
+  const position = positions[Math.floor(Math.random() * positions.length)];
+  const attributes = {
     strength: randomAttr(),
     acceleration: randomAttr(),
     topSpeed: randomAttr(),
@@ -28,12 +26,20 @@ const generatePlayer = (id: number): Player => ({
     positioning: randomAttr(),
     reaction: randomAttr(),
     ballControl: randomAttr(),
-  },
-  age: Math.floor(Math.random() * 17) + 18,
-  height: 180,
-  weight: 75,
-  squadRole: 'reserve',
-});
+  } as Player['attributes'];
+  return {
+    id: String(id),
+    name: generateRandomName(),
+    position,
+    roles: getRoles(position),
+    overall: calculateOverall(position, attributes),
+    attributes,
+    age: Math.floor(Math.random() * 17) + 18,
+    height: 180,
+    weight: 75,
+    squadRole: 'reserve',
+  };
+};
 
 const generateTeamData = (id: string, name: string, manager: string): ClubTeam => {
   const players: Player[] = Array.from({ length: 30 }, (_, i) => generatePlayer(i + 1));

--- a/src/services/youth.test.ts
+++ b/src/services/youth.test.ts
@@ -26,6 +26,7 @@ const player: Player = {
   id: 'p1',
   name: 'Test',
   position: 'GK',
+  roles: ['GK'],
   overall: 0.5,
   attributes: {
     strength: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,20 +1,23 @@
 export type SquadRole = 'starting' | 'bench' | 'reserve';
 
+export type Position =
+  | 'GK'
+  | 'CB'
+  | 'LB'
+  | 'RB'
+  | 'CM'
+  | 'LM'
+  | 'RM'
+  | 'CAM'
+  | 'LW'
+  | 'RW'
+  | 'ST';
+
 export interface Player {
   id: string;
   name: string;
-  position:
-    | 'GK'
-    | 'CB'
-    | 'LB'
-    | 'RB'
-    | 'CM'
-    | 'LM'
-    | 'RM'
-    | 'CAM'
-    | 'LW'
-    | 'RW'
-    | 'ST';
+  position: Position;
+  roles: Position[];
   overall: number;
   attributes: {
     strength: number;


### PR DESCRIPTION
## Summary
- allow players to have multiple playable roles
- compute overall ratings using position-relevant attributes
- apply role assignment and overall calculation when generating team and youth players

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9f0e64a44832aa642ec50f85c3e8d