### PR TITLE
Display playable positions on player cards

### DIFF
--- a/src/components/ui/loading-skeleton.tsx
+++ b/src/components/ui/loading-skeleton.tsx
@@ -6,7 +6,10 @@ export const PlayerCardSkeleton = () => (
       <Skeleton className="w-12 h-12 rounded-full" />
       <div className="flex-1 space-y-2">
         <Skeleton className="h-4 w-24" />
-        <Skeleton className="h-3 w-16" />
+        <div className="flex gap-2">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-3 w-10" />
+        </div>
       </div>
     </div>
     <div className="space-y-2">

--- a/src/components/ui/player-card.tsx
+++ b/src/components/ui/player-card.tsx
@@ -69,6 +69,13 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
                   <TrendingUp className="w-3 h-3" />
                   <span className="font-semibold">{player.overall.toFixed(3)}</span>
                 </div>
+                <div className="flex gap-1">
+                  {player.roles.map(role => (
+                    <Badge key={role} variant="outline" className="text-xs">
+                      {role}
+                    </Badge>
+                  ))}
+                </div>
               </div>
             </div>
             

--- a/src/features/academy/CandidateCard.tsx
+++ b/src/features/academy/CandidateCard.tsx
@@ -10,6 +10,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { getRoles } from '@/lib/player';
+import type { Player } from '@/types';
 
 interface Props {
   candidate: AcademyCandidate;
@@ -17,8 +19,19 @@ interface Props {
   onRelease: (id: string) => void;
 }
 
+const mapPosition = (pos: string): Player['position'] => {
+  const mapping: Record<string, Player['position']> = {
+    GK: 'GK',
+    DEF: 'CB',
+    MID: 'CM',
+    FWD: 'ST',
+  };
+  return mapping[pos] || 'CM';
+};
+
 const CandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease }) => {
   const { player } = candidate;
+  const roles = getRoles(mapPosition(player.position));
   const initials = player.name
     .split(' ')
     .map((n) => n[0])
@@ -50,6 +63,13 @@ const CandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease }) => {
                 <div className="flex items-center gap-1 text-xs text-muted-foreground">
                   <TrendingUp className="w-3 h-3" />
                   <span className="font-semibold">{player.overall.toFixed(3)}</span>
+                </div>
+                <div className="flex gap-1">
+                  {roles.map((role) => (
+                    <Badge key={role} variant="outline" className="text-xs">
+                      {role}
+                    </Badge>
+                  ))}
                 </div>
               </div>
             </div>

--- a/src/features/youth/YouthCandidateCard.tsx
+++ b/src/features/youth/YouthCandidateCard.tsx
@@ -65,6 +65,13 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                   <TrendingUp className="w-3 h-3" />
                   <span className="font-semibold">{player.overall.toFixed(3)}</span>
                 </div>
+                <div className="flex gap-1">
+                  {player.roles.map((role) => (
+                    <Badge key={role} variant="outline" className="text-xs">
+                      {role}
+                    </Badge>
+                  ))}
+                </div>
               </div>
             </div>
             <div className="flex gap-1">


### PR DESCRIPTION
## Summary
- show role badges next to age/overall on team player cards
- show role badges on youth and academy candidate cards
- adjust player card skeleton to include placeholder for roles

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9f99e2cf0832a876b5e20755dc301