### PR TITLE
Fix PlayerCard roles undefined error

### DIFF
--- a/src/components/ui/player-card.tsx
+++ b/src/components/ui/player-card.tsx
@@ -70,7 +70,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
                   <span className="font-semibold">{player.overall.toFixed(3)}</span>
                 </div>
                 <div className="flex gap-1">
-                  {player.roles.map(role => (
+                  {(player.roles ?? []).map((role) => (
                     <Badge key={role} variant="outline" className="text-xs">
                       {role}
                     </Badge>


### PR DESCRIPTION
## Summary
- avoid runtime error when player roles are undefined by defaulting to empty array

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9fb69d3d0832aa0f97e150e45907a