### PR TITLE
feat: add player potential and scale ratings to 100

### DIFF
--- a/src/components/ui/player-card.tsx
+++ b/src/components/ui/player-card.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface PlayerCardProps {
   player: Player;
@@ -67,7 +68,16 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
                 <Badge variant="secondary" className="text-xs">{player.age} yaş</Badge>
                 <div className="flex items-center gap-1 text-xs text-muted-foreground">
                   <TrendingUp className="w-3 h-3" />
-                  <span className="font-semibold">{player.overall.toFixed(3)}</span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="font-semibold">
+                        {Math.round(player.overall * 100)}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Maks. Potansiyel: {Math.round(player.potential * 100)}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 <div className="flex gap-1">
                   {(player.roles ?? []).map((role) => (

--- a/src/components/ui/stat-bar.tsx
+++ b/src/components/ui/stat-bar.tsx
@@ -19,7 +19,7 @@ export const StatBar: React.FC<StatBarProps> = ({
     <div className={`space-y-1 ${className}`}>
       <div className="flex justify-between items-center text-xs">
         <span className="text-muted-foreground font-medium">{label}</span>
-        <span className="text-foreground font-semibold">{value.toFixed(3)}</span>
+        <span className="text-foreground font-semibold">{percentage.toFixed(0)}</span>
       </div>
       <Progress value={percentage} className="h-2" />
     </div>

--- a/src/features/academy/CandidateCard.tsx
+++ b/src/features/academy/CandidateCard.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { getRoles } from '@/lib/player';
 import type { Player } from '@/types';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface Props {
   candidate: AcademyCandidate;
@@ -62,7 +63,16 @@ const CandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease }) => {
                 </Badge>
                 <div className="flex items-center gap-1 text-xs text-muted-foreground">
                   <TrendingUp className="w-3 h-3" />
-                  <span className="font-semibold">{player.overall.toFixed(3)}</span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="font-semibold">
+                        {Math.round(player.overall * 100)}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Maks. Potansiyel: {Math.round(player.potential * 100)}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 <div className="flex gap-1">
                   {roles.map((role) => (

--- a/src/features/youth/YouthCandidateCard.tsx
+++ b/src/features/youth/YouthCandidateCard.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { StatBar } from '@/components/ui/stat-bar';
 import { Button } from '@/components/ui/button';
 import { TrendingUp } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface Props {
   candidate: YouthCandidate;
@@ -63,7 +64,16 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                 </Badge>
                 <div className="flex items-center gap-1 text-xs text-muted-foreground">
                   <TrendingUp className="w-3 h-3" />
-                  <span className="font-semibold">{player.overall.toFixed(3)}</span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="font-semibold">
+                        {Math.round(player.overall * 100)}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Maks. Potansiyel: {Math.round(player.potential * 100)}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 <div className="flex gap-1">
                   {player.roles.map((role) => (

--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -41,12 +41,15 @@ const generatePlayer = (): Player => {
     reaction: randomAttr(),
     ballControl: randomAttr(),
   } as Player['attributes'];
+  const overall = calculateOverall(position, attributes);
+  const potential = Math.min(1, overall + Math.random() * (1 - overall));
   return {
     id: crypto.randomUUID(),
     name: generateRandomName(),
     position,
     roles: getRoles(position),
-    overall: calculateOverall(position, attributes),
+    overall,
+    potential,
     attributes,
     age: Math.floor(Math.random() * 5) + 16,
     height: 180,

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -22,7 +22,7 @@ const createAttributes = (attrs: Partial<Player['attributes']>): Player['attribu
 
 const defaultPhysical = { height: 180, weight: 75 };
 
-export const mockPlayers: Player[] = [
+const rawMockPlayers: Omit<Player, 'potential'>[] = [
   {
     id: '1',
     name: 'Mehmet Özkan',
@@ -347,6 +347,11 @@ export const youthPlayers: Player[] = [
     ...defaultPhysical,
   },
 ];
+
+export const mockPlayers: Player[] = rawMockPlayers.map((p) => ({
+  ...p,
+  potential: Math.min(1, p.overall + Math.random() * (1 - p.overall)),
+}));
 
 export const upcomingMatches: Match[] = [
   {

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -171,7 +171,7 @@ export default function TrainingPage() {
         return {
           ...p,
           attributes: { ...p.attributes, [training.type]: newAttr },
-          overall: Math.min(parseFloat((p.overall + gain / 10).toFixed(3)), 1),
+          overall: Math.min(parseFloat((p.overall + gain / 10).toFixed(3)), p.potential),
         };
       });
       setPlayers(updatedPlayers);
@@ -255,7 +255,7 @@ export default function TrainingPage() {
                 <SelectContent>
                   {players.filter(p => p.squadRole === 'starting').map(player => (
                     <SelectItem key={player.id} value={player.id}>
-                      {player.name} ({player.position}) - {player.overall.toFixed(3)}
+                    {player.name} ({player.position}) - {Math.round(player.overall * 100)}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/services/academy.ts
+++ b/src/services/academy.ts
@@ -162,6 +162,7 @@ function candidateToPlayer(id: string, c: CandidatePlayer): Player {
     position,
     roles: getRoles(position),
     overall: calculateOverall(position, attributes),
+    potential: c.potential,
     attributes,
     age: c.age,
     height: 180,

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -27,12 +27,15 @@ const generatePlayer = (id: number): Player => {
     reaction: randomAttr(),
     ballControl: randomAttr(),
   } as Player['attributes'];
+  const overall = calculateOverall(position, attributes);
+  const potential = Math.min(1, overall + Math.random() * (1 - overall));
   return {
     id: String(id),
     name: generateRandomName(),
     position,
     roles: getRoles(position),
-    overall: calculateOverall(position, attributes),
+    overall,
+    potential,
     attributes,
     age: Math.floor(Math.random() * 17) + 18,
     height: 180,

--- a/src/services/youth.test.ts
+++ b/src/services/youth.test.ts
@@ -28,6 +28,7 @@ const player: Player = {
   position: 'GK',
   roles: ['GK'],
   overall: 0.5,
+  potential: 0.9,
   attributes: {
     strength: 0,
     acceleration: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface Player {
   position: Position;
   roles: Position[];
   overall: number;
+  potential: number;
   attributes: {
     strength: number;
     acceleration: number;


### PR DESCRIPTION
## Summary
- add `potential` to player model and seed random max potential
- scale player ratings and attributes to 0-100 with tooltip showing max potential
- prevent training gains from exceeding a player's potential

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9fe27d16c832a8cad1f94a324d01e