### PR TITLE
Recalculate player overall from position stats

### DIFF
--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -14,8 +14,17 @@ const POSITION_ATTRIBUTES: Record<Player['position'], (keyof Player['attributes'
   ST: ['shooting', 'shootPower', 'positioning', 'strength', 'topSpeed'],
 };
 
-export function calculateOverall(position: Player['position'], attributes: Player['attributes']): number {
-  const keys = POSITION_ATTRIBUTES[position];
+export function getPositionAttributes(
+  position: Player['position']
+): (keyof Player['attributes'])[] {
+  return POSITION_ATTRIBUTES[position];
+}
+
+export function calculateOverall(
+  position: Player['position'],
+  attributes: Player['attributes']
+): number {
+  const keys = getPositionAttributes(position);
   const total = keys.reduce((sum, key) => sum + attributes[key], 0);
   return parseFloat((total / keys.length).toFixed(3));
 }

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { StatBar } from '@/components/ui/stat-bar';
 import { trainings } from '@/lib/data';
+import { calculateOverall } from '@/lib/player';
 import { Player, Training } from '@/types';
 import { Dumbbell, Play, TrendingUp, Clock } from 'lucide-react';
 import { toast } from 'sonner';
@@ -168,10 +169,14 @@ export default function TrainingPage() {
       const updatedPlayers = players.map(p => {
         if (p.id !== player.id) return p;
         const newAttr = Math.min(p.attributes[training.type] + gain, 1);
+        const newAttributes = { ...p.attributes, [training.type]: newAttr };
         return {
           ...p,
-          attributes: { ...p.attributes, [training.type]: newAttr },
-          overall: Math.min(parseFloat((p.overall + gain / 10).toFixed(3)), p.potential),
+          attributes: newAttributes,
+          overall: Math.min(
+            calculateOverall(p.position, newAttributes),
+            p.potential
+          ),
         };
       });
       setPlayers(updatedPlayers);


### PR DESCRIPTION
## Summary
- expose position-specific attribute list and update overall calculation helper
- recalculate player overall after training using relevant position attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa01b822c0832a950aae8f3397f87f