### PR TITLE
Persist youth candidates via Firestore

### DIFF
--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -5,6 +5,7 @@ import { useDiamonds } from '@/contexts/DiamondContext';
 import { toast } from 'sonner';
 import {
   listenYouthCandidates,
+  getYouthCandidates,
   createYouthCandidate,
   acceptYouthCandidate,
   releaseYouthCandidate,
@@ -67,6 +68,7 @@ const YouthPage = () => {
 
   useEffect(() => {
     if (!user?.id) return;
+    getYouthCandidates(user.id).then(setCandidates).catch(console.warn);
     return listenYouthCandidates(user.id, setCandidates);
   }, [user?.id]);
 
@@ -101,8 +103,7 @@ const YouthPage = () => {
     if (!user?.id) return;
     try {
       const player = generatePlayer();
-      const candidate = await createYouthCandidate(user.id, player);
-      setCandidates((prev) => [candidate, ...prev]);
+      await createYouthCandidate(user.id, player);
       setNextGenerateAt(new Date(Date.now() + YOUTH_COOLDOWN_MS));
       toast.success('Oyuncu üretildi');
     } catch (err) {

--- a/src/services/youth.test.ts
+++ b/src/services/youth.test.ts
@@ -20,6 +20,11 @@ vi.mock('firebase/firestore', () => ({
   serverTimestamp: vi.fn(),
   Timestamp: { fromDate: (...args: unknown[]) => fromDateMock(...args) },
   increment: vi.fn(),
+  getDocs: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  onSnapshot: vi.fn(),
 }));
 
 const player: Player = {

--- a/src/services/youth.ts
+++ b/src/services/youth.ts
@@ -6,6 +6,7 @@ import {
   orderBy,
   doc,
   getDoc,
+  getDocs,
   deleteDoc,
   Unsubscribe,
   serverTimestamp,
@@ -31,6 +32,16 @@ interface UserDoc {
   youth?: {
     nextGenerateAt?: Timestamp;
   };
+}
+
+export async function getYouthCandidates(uid: string): Promise<YouthCandidate[]> {
+  const col = collection(db, 'users', uid, 'youthCandidates');
+  const q = query(col, where('status', '==', 'pending'), orderBy('createdAt', 'desc'));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({
+    id: d.id,
+    ...(d.data() as Omit<YouthCandidate, 'id'>),
+  }));
 }
 
 export function listenYouthCandidates(


### PR DESCRIPTION
## Summary
- load existing youth candidates from Firestore on page mount
- persist generated candidates only through Firestore and remove local duplicates
- mock new Firestore utilities in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa031c7dc8832a819fefd80129419f