### PR TITLE
feat: store active training in firestore

### DIFF
--- a/src/services/training.ts
+++ b/src/services/training.ts
@@ -1,0 +1,26 @@
+import { doc, setDoc, getDoc, deleteDoc, Timestamp } from 'firebase/firestore';
+import { db } from '@/services/firebase';
+
+export interface ActiveTrainingSession {
+  playerId: string;
+  playerName: string;
+  trainingId: string;
+  trainingName: string;
+  startAt: Timestamp;
+  endAt: Timestamp;
+}
+
+const trainingDoc = (uid: string) => doc(db, 'users', uid, 'training', 'active');
+
+export async function getActiveTraining(uid: string): Promise<ActiveTrainingSession | null> {
+  const snap = await getDoc(trainingDoc(uid));
+  return snap.exists() ? (snap.data() as ActiveTrainingSession) : null;
+}
+
+export async function setActiveTraining(uid: string, session: ActiveTrainingSession): Promise<void> {
+  await setDoc(trainingDoc(uid), session);
+}
+
+export async function clearActiveTraining(uid: string): Promise<void> {
+  await deleteDoc(trainingDoc(uid));
+}


### PR DESCRIPTION
## Summary
- track active training sessions in Firestore instead of localStorage
- restore and clear sessions from the database

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aabf3c2148832a9fe82efff918b693