### PR TITLE
Fix active training display

### DIFF
--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -20,6 +20,8 @@ export default function TrainingPage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
   const [selectedTraining, setSelectedTraining] = useState<Training | null>(null);
+  const [activePlayer, setActivePlayer] = useState<Player | null>(null);
+  const [activeTraining, setActiveTraining] = useState<Training | null>(null);
   const [isTraining, setIsTraining] = useState(false);
   const [timeLeft, setTimeLeft] = useState(0);
   const [playersLoaded, setPlayersLoaded] = useState(false);
@@ -51,15 +53,15 @@ export default function TrainingPage() {
 
       const remaining = Math.round((session.endAt.toMillis() - Date.now()) / 1000);
 
+      setSelectedPlayer(player);
+      setSelectedTraining(training);
+      setActivePlayer(player);
+      setActiveTraining(training);
+
       if (remaining <= 0) {
-        setSelectedPlayer(player);
-        setSelectedTraining(training);
-        setIsTraining(true);
         setTimeLeft(0);
         await completeTraining(player, training);
       } else {
-        setSelectedPlayer(player);
-        setSelectedTraining(training);
         setIsTraining(true);
         setTimeLeft(remaining);
 
@@ -98,6 +100,8 @@ export default function TrainingPage() {
       endAt: Timestamp.fromMillis(endTime),
     });
 
+    setActivePlayer(selectedPlayer);
+    setActiveTraining(selectedTraining);
     setIsTraining(true);
     setTimeLeft(duration);
 
@@ -128,11 +132,13 @@ export default function TrainingPage() {
       clearInterval(intervalRef.current);
     }
 
-    const player = playerOverride || selectedPlayer;
-    const training = trainingOverride || selectedTraining;
+    const player = playerOverride || activePlayer;
+    const training = trainingOverride || activeTraining;
 
     if (!player || !training || !user) {
       setIsTraining(false);
+      setActivePlayer(null);
+      setActiveTraining(null);
       if (user) await clearActiveTraining(user.id);
       return;
     }
@@ -173,6 +179,8 @@ export default function TrainingPage() {
 
     setIsTraining(false);
     setTimeLeft(0);
+    setActivePlayer(null);
+    setActiveTraining(null);
     await clearActiveTraining(user.id);
   };
 
@@ -202,7 +210,7 @@ export default function TrainingPage() {
       </div>
 
       <div className="p-4 space-y-6">
-        {isTraining && selectedPlayer && selectedTraining && (
+        {isTraining && activePlayer && activeTraining && (
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
@@ -213,8 +221,8 @@ export default function TrainingPage() {
             <CardContent>
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="font-semibold">{selectedPlayer.name}</p>
-                  <p className="text-sm text-muted-foreground">{selectedTraining.name}</p>
+                  <p className="font-semibold">{activePlayer.name}</p>
+                  <p className="text-sm text-muted-foreground">{activeTraining.name}</p>
                 </div>
                 <div className="flex items-center gap-1 text-sm text-muted-foreground">
                   <Clock className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- keep active training info separate from selection state
- update session restoration and completion to use new active training state
- ensure active training card shows correct player and drill

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac84de3c4832aa89e4c073742fcbe