### PR TITLE
Show max stat value on hover

### DIFF
--- a/src/components/ui/stat-bar.tsx
+++ b/src/components/ui/stat-bar.tsx
@@ -1,4 +1,9 @@
 import { Progress } from "@/components/ui/progress";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface StatBarProps {
   label: string;
@@ -16,12 +21,21 @@ export const StatBar: React.FC<StatBarProps> = ({
   const percentage = Math.min((value / max) * 100, 100);
   
   return (
-    <div className={`space-y-1 ${className}`}>
-      <div className="flex justify-between items-center text-xs">
-        <span className="text-muted-foreground font-medium">{label}</span>
-        <span className="text-foreground font-semibold">{percentage.toFixed(0)}</span>
-      </div>
-      <Progress value={percentage} className="h-2" />
-    </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className={`space-y-1 ${className}`}>
+          <div className="flex justify-between items-center text-xs">
+            <span className="text-muted-foreground font-medium">{label}</span>
+            <span className="text-foreground font-semibold">
+              {percentage.toFixed(0)}
+            </span>
+          </div>
+          <Progress value={percentage} className="h-2" />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        Maks: {Math.round(max * 100)}
+      </TooltipContent>
+    </Tooltip>
   );
 };


### PR DESCRIPTION
## Summary
- display max stat in tooltip on stat bars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aca5ca7ab4832a860c302eeceac080