### PR TITLE
Cap player attributes by potential

### DIFF
--- a/src/lib/player.test.ts
+++ b/src/lib/player.test.ts
@@ -2,23 +2,23 @@ import { expect, test } from 'vitest';
 import { assignMaxStats, getPositionAttributes } from './player';
 import type { Player } from '@/types';
 
-test('assigns max stats based on roles without exceeding average', () => {
+test('assigns max stats based on roles without exceeding potential', () => {
   const baseAttributes: Player['attributes'] = {
-    strength: 10,
-    acceleration: 10,
-    topSpeed: 10,
-    dribbleSpeed: 10,
-    jump: 10,
-    tackling: 10,
-    ballKeeping: 10,
-    passing: 10,
-    longBall: 10,
-    agility: 10,
-    shooting: 10,
-    shootPower: 10,
-    positioning: 10,
-    reaction: 10,
-    ballControl: 10,
+    strength: 0.1,
+    acceleration: 0.1,
+    topSpeed: 0.1,
+    dribbleSpeed: 0.1,
+    jump: 0.1,
+    tackling: 0.1,
+    ballKeeping: 0.1,
+    passing: 0.1,
+    longBall: 0.1,
+    agility: 0.1,
+    shooting: 0.1,
+    shootPower: 0.1,
+    positioning: 0.1,
+    reaction: 0.1,
+    ballControl: 0.1,
   };
 
   const player: Player = {
@@ -26,8 +26,8 @@ test('assigns max stats based on roles without exceeding average', () => {
     name: 'Test Player',
     position: 'CM',
     roles: ['CM', 'CAM'],
-    overall: 10,
-    potential: 100,
+    overall: 0.1,
+    potential: 0.9,
     attributes: baseAttributes,
     age: 20,
     height: 180,
@@ -35,7 +35,7 @@ test('assigns max stats based on roles without exceeding average', () => {
     squadRole: 'starting',
   };
 
-  const updated = assignMaxStats(player, 90);
+  const updated = assignMaxStats(player);
 
   const relevant = new Set<keyof Player['attributes']>([
     ...getPositionAttributes('CM'),
@@ -43,12 +43,12 @@ test('assigns max stats based on roles without exceeding average', () => {
   ]);
 
   relevant.forEach((attr) => {
-    expect(updated.attributes[attr]).toBe(90);
+    expect(updated.attributes[attr]).toBe(0.9);
   });
 
   // A non-relevant attribute should remain unchanged
   expect(updated.attributes.longBall).toBe(baseAttributes.longBall);
 
-  // overall should match the maximum average for the main position
-  expect(updated.overall).toBe(90);
+  // overall should match the player's potential for the main position
+  expect(updated.overall).toBe(0.9);
 });

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -48,22 +48,16 @@ export function getRoles(position: Player['position']): Player['position'][] {
 }
 
 /**
- * Assigns maximum attribute values for the roles a player can perform while
- * ensuring the average of those attributes does not exceed the provided
- * `maxAverage`.
+ * Sets a player's role-specific attributes to their maximum allowed value
+ * without exceeding the player's maximum overall rating.
  *
- * The function sets all attributes relevant to the player's roles to
- * `maxValue` (defaults to 100). If the average of these attributes is higher
- * than `maxAverage`, they are scaled down proportionally.
- *
- * If `maxAverage` is not supplied, the player's current overall for their main
- * position is used. This guarantees that overall ratings are calculated based
- * on the player's position before applying the maximum stats.
+ * `maxOverall` defaults to the player's potential and represents the highest
+ * rating the player can reach. Each relevant attribute is set to this value,
+ * ensuring no attribute surpasses the maximum overall.
  */
 export function assignMaxStats(
   player: Player,
-  maxAverage = calculateOverall(player.position, player.attributes),
-  maxValue = 100,
+  maxOverall = player.potential,
 ): Player {
   const attributes = { ...player.attributes };
 
@@ -73,20 +67,12 @@ export function assignMaxStats(
     getPositionAttributes(role).forEach((attr) => relevant.add(attr));
   });
 
-  // Assign the max value to all relevant attributes
-  relevant.forEach((attr) => {
-    attributes[attr] = maxValue;
-  });
+  const cap = Math.min(maxOverall, player.potential);
 
-  // Scale down if the average exceeds the allowed maximum
-  const total = Array.from(relevant).reduce((sum, attr) => sum + attributes[attr], 0);
-  const avg = total / relevant.size;
-  if (avg > maxAverage) {
-    const scale = maxAverage / avg;
-    relevant.forEach((attr) => {
-      attributes[attr] = parseFloat((attributes[attr] * scale).toFixed(3));
-    });
-  }
+  // Assign the capped value to all relevant attributes
+  relevant.forEach((attr) => {
+    attributes[attr] = cap;
+  });
 
   return {
     ...player,

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -164,7 +164,7 @@ export default function TrainingPage() {
     if (gain > 0) {
       const updatedPlayers = players.map(p => {
         if (p.id !== player.id) return p;
-        const newAttr = Math.min(p.attributes[training.type] + gain, 1);
+        const newAttr = Math.min(p.attributes[training.type] + gain, p.potential);
         const newAttributes = { ...p.attributes, [training.type]: newAttr };
         return {
           ...p,


### PR DESCRIPTION
## Summary
- align max stat assignment with player's potential instead of hard 100
- cap training stat gains at player potential
- update tests for new max stat logic

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb36818e4832aa65d1a943c1575d1