### PR TITLE
feat: training history sidebar and stat fixes

### DIFF
--- a/src/services/training.test.ts
+++ b/src/services/training.test.ts
@@ -4,19 +4,52 @@ import { finishTrainingWithDiamonds } from './training';
 vi.mock('./firebase', () => ({ db: {} }));
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
-const docMock = vi.fn();
-const runTransactionMock = vi.fn();
-const incrementMock = vi.fn();
+const {
+  docMock,
+  runTransactionMock,
+  incrementMock,
+  setDocMock,
+  getDocMock,
+  deleteDocMock,
+  collectionMock,
+  addDocMock,
+  getDocsMock,
+  TimestampMock,
+} = vi.hoisted(() => ({
+  docMock: vi.fn(),
+  runTransactionMock: vi.fn(),
+  incrementMock: vi.fn(),
+  setDocMock: vi.fn(),
+  getDocMock: vi.fn(),
+  deleteDocMock: vi.fn(),
+  collectionMock: vi.fn(),
+  addDocMock: vi.fn(),
+  getDocsMock: vi.fn(),
+  TimestampMock: { now: vi.fn(), fromMillis: vi.fn() },
+}));
 
 vi.mock('firebase/firestore', () => ({
   doc: (...args: unknown[]) => docMock(...args),
   runTransaction: (...args: unknown[]) => runTransactionMock(...args),
   increment: (...args: unknown[]) => incrementMock(...args),
+  setDoc: (...args: unknown[]) => setDocMock(...args),
+  getDoc: (...args: unknown[]) => getDocMock(...args),
+  deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
+  collection: (...args: unknown[]) => collectionMock(...args),
+  addDoc: (...args: unknown[]) => addDocMock(...args),
+  getDocs: (...args: unknown[]) => getDocsMock(...args),
+  Timestamp: TimestampMock,
 }));
 
 beforeEach(() => {
   docMock.mockReset();
   runTransactionMock.mockReset();
+  setDocMock.mockReset();
+  getDocMock.mockReset();
+  deleteDocMock.mockReset();
+  collectionMock.mockReset();
+  addDocMock.mockReset();
+  getDocsMock.mockReset();
 });
 
 describe('finishTrainingWithDiamonds', () => {

--- a/src/services/training.ts
+++ b/src/services/training.ts
@@ -6,6 +6,9 @@ import {
   Timestamp,
   runTransaction,
   increment,
+  collection,
+  addDoc,
+  getDocs,
 } from 'firebase/firestore';
 import { db } from '@/services/firebase';
 import { toast } from 'sonner';
@@ -19,7 +22,20 @@ export interface ActiveTrainingSession {
   endAt: Timestamp;
 }
 
+export interface TrainingHistoryRecord {
+  id?: string;
+  playerId: string;
+  playerName: string;
+  trainingId: string;
+  trainingName: string;
+  result: 'success' | 'average' | 'fail';
+  gain: number;
+  completedAt: Timestamp;
+}
+
 const trainingDoc = (uid: string) => doc(db, 'users', uid, 'training', 'active');
+const trainingHistoryCol = (uid: string) =>
+  collection(db, 'users', uid, 'trainingHistory');
 
 export async function getActiveTraining(uid: string): Promise<ActiveTrainingSession | null> {
   const snap = await getDoc(trainingDoc(uid));
@@ -32,6 +48,20 @@ export async function setActiveTraining(uid: string, session: ActiveTrainingSess
 
 export async function clearActiveTraining(uid: string): Promise<void> {
   await deleteDoc(trainingDoc(uid));
+}
+
+export async function addTrainingRecord(
+  uid: string,
+  record: TrainingHistoryRecord,
+): Promise<void> {
+  await addDoc(trainingHistoryCol(uid), record);
+}
+
+export async function getTrainingHistory(
+  uid: string,
+): Promise<TrainingHistoryRecord[]> {
+  const snap = await getDocs(trainingHistoryCol(uid));
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as TrainingHistoryRecord) }));
 }
 
 export const TRAINING_FINISH_COST = 50;


### PR DESCRIPTION
## Summary
- save completed trainings to firestore and expose retrieval helpers
- add collapsible training history sidebar with filtering options
- fix training stat updates to allow progress up to 100%

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb8c59ca4832aae47845f9c5c4cdc