### PR TITLE
Move training finish button and verify coverage

### DIFF
--- a/src/lib/trainings.test.ts
+++ b/src/lib/trainings.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { trainings } from './data';
+import type { Player } from '@/types';
+
+describe('training options', () => {
+  it('covers all player attributes', () => {
+    const attributeKeys: (keyof Player['attributes'])[] = [
+      'strength',
+      'acceleration',
+      'topSpeed',
+      'dribbleSpeed',
+      'jump',
+      'tackling',
+      'ballKeeping',
+      'passing',
+      'longBall',
+      'agility',
+      'shooting',
+      'shootPower',
+      'positioning',
+      'reaction',
+      'ballControl',
+    ];
+
+    const trainingTypes = trainings.map(t => t.type);
+    attributeKeys.forEach(key => {
+      expect(trainingTypes).toContain(key);
+    });
+  });
+});

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -392,15 +392,6 @@ export default function TrainingPage() {
                   {formatTime(timeLeft)}
                 </div>
               </div>
-              <Button
-                onClick={handleFinishWithDiamonds}
-                className="mt-4 w-full"
-                variant="secondary"
-                disabled={balance < TRAINING_FINISH_COST}
-              >
-                <Diamond className="h-4 w-4 mr-1" />
-                {TRAINING_FINISH_COST} Elmas ile bitir
-              </Button>
             </CardContent>
           </Card>
         )}
@@ -576,6 +567,18 @@ export default function TrainingPage() {
                 </>
               )}
             </Button>
+
+            {isTraining && selectedPlayer && selectedTraining && (
+              <Button
+                onClick={handleFinishWithDiamonds}
+                className="mt-4 w-full"
+                variant="secondary"
+                disabled={balance < TRAINING_FINISH_COST}
+              >
+                <Diamond className="h-4 w-4 mr-1" />
+                {TRAINING_FINISH_COST} Elmas ile bitir
+              </Button>
+            )}
 
             {(!selectedPlayer || !selectedTraining) && (
               <p className="text-center text-sm text-muted-foreground mt-2">


### PR DESCRIPTION
## Summary
- Move diamond-based "finish training" button below the start training button for better UI grouping
- Add unit test ensuring training options exist for every upgradeable player stat

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acbdf3caf4832aaeacdc155f2c7fc9