### PR TITLE
feat: show role and name on field

### DIFF
--- a/src/pages/TeamPlanning.tsx
+++ b/src/pages/TeamPlanning.tsx
@@ -204,13 +204,19 @@ export default function TeamPlanning() {
                       onDrop={() => handlePositionDrop(position)}
                     >
                       <div
-                        className="w-12 h-12 rounded-full bg-white/80 flex items-center justify-center cursor-move"
+                        className="w-12 h-12 rounded-full bg-white/80 flex flex-col items-center justify-center cursor-move text-[8px] leading-tight"
                         draggable={!!player}
                         onDragStart={() => player && setDraggedPlayerId(player.id)}
                         onDragEnd={() => setDraggedPlayerId(null)}
                       >
-
-                        {player ? player.name.split(' ')[0] : position}
+                        {player ? (
+                          <>
+                            <span className="text-[9px] font-semibold">{position}</span>
+                            <span>{player.name.split(' ')[0]}</span>
+                          </>
+                        ) : (
+                          <span className="text-[9px] font-semibold">{position}</span>
+                        )}
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
## Summary
- show role and player name on formation circles in team planning view

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc0448624832a8509e737791ffaf3