### PR TITLE
Ensure defenders render and show tooltip details

### DIFF
--- a/src/pages/TeamPlanning.tsx
+++ b/src/pages/TeamPlanning.tsx
@@ -217,7 +217,7 @@ export default function TeamPlanning() {
                           </TooltipTrigger>
                           <TooltipContent>
                             <div className="text-xs">
-                              {position} - {player.overall}
+                              {player.position} - {Math.round(player.overall * 100)}
                             </div>
                           </TooltipContent>
                         </Tooltip>

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -3,13 +3,18 @@ import { db } from '@/services/firebase';
 import { Player, ClubTeam } from '@/types';
 import { generateRandomName } from '@/lib/names';
 import { calculateOverall, getRoles } from '@/lib/player';
+import { formations } from '@/lib/formations';
 
 const positions: Player['position'][] = ['GK','CB','LB','RB','CM','LM','RM','CAM','LW','RW','ST'];
 
 const randomAttr = () => parseFloat(Math.random().toFixed(3));
 
-const generatePlayer = (id: number): Player => {
-  const position = positions[Math.floor(Math.random() * positions.length)];
+const generatePlayer = (
+  id: number,
+  forcedPosition?: Player['position'],
+): Player => {
+  const position =
+    forcedPosition || positions[Math.floor(Math.random() * positions.length)];
   const attributes = {
     strength: randomAttr(),
     acceleration: randomAttr(),
@@ -45,7 +50,14 @@ const generatePlayer = (id: number): Player => {
 };
 
 const generateTeamData = (id: string, name: string, manager: string): ClubTeam => {
-  const players: Player[] = Array.from({ length: 30 }, (_, i) => generatePlayer(i + 1));
+  const players: Player[] = [];
+  const startingPositions = formations[0].positions.map(p => p.position);
+  startingPositions.forEach((pos, idx) => {
+    players.push(generatePlayer(idx + 1, pos));
+  });
+  for (let i = startingPositions.length; i < 30; i++) {
+    players.push(generatePlayer(i + 1));
+  }
   players.slice(0, 11).forEach(p => (p.squadRole = 'starting'));
   players.slice(11, 22).forEach(p => (p.squadRole = 'bench'));
   players.slice(22).forEach(p => (p.squadRole = 'reserve'));


### PR DESCRIPTION
## Summary
- guarantee initial team includes defenders by generating players for default formation
- display player's position and rating (0-100) in formation tooltips

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68accaf2f8c0832abf766cdc3d5192ea