### PR TITLE
Display player names with hover info in team formation

### DIFF
--- a/src/pages/TeamPlanning.tsx
+++ b/src/pages/TeamPlanning.tsx
@@ -211,8 +211,11 @@ export default function TeamPlanning() {
                               draggable
                               onDragStart={() => setDraggedPlayerId(player.id)}
                               onDragEnd={() => setDraggedPlayerId(null)}
+                              title={`${player.position} - ${Math.round(player.overall * 100)}`}
                             >
-                              <span className="text-[9px] font-semibold">{player.name.split(' ')[0]}</span>
+                              <span className="text-[9px] font-semibold text-center">
+                                {player.name}
+                              </span>
                             </div>
                           </TooltipTrigger>
                           <TooltipContent>


### PR DESCRIPTION
## Summary
- Show each player's full name in the green team formation view
- Provide position and overall rating on hover for formation players

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acce448f68832a95e24ee1121d59ea