### PR TITLE
Add 22-team league scheduling and fixtures

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,22 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "fixtures",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "participants", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "standings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "Pts", "order": "DESCENDING" },
+        { "fieldPath": "GD", "order": "DESCENDING" },
+        { "fieldPath": "GF", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,5 +10,25 @@ service cloud.firestore {
         allow read, write: if request.auth != null && request.auth.uid == uid;
       }
     }
+
+    match /leagues/{leagueId} {
+      allow read: if true;
+      allow write: if false;
+
+      match /teams/{teamId} {
+        allow read: if true;
+        allow write: if false;
+      }
+
+      match /fixtures/{matchId} {
+        allow read: if true;
+        allow write: if false;
+      }
+
+      match /standings/{teamId} {
+        allow read: if true;
+        allow write: if false;
+      }
+    }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "functions",
+  "type": "module",
+  "engines": { "node": "18" },
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.11.1",
+    "firebase-functions": "^4.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.3"
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,2 @@
+export { assignTeamToLeague, generateRoundRobinFixturesFn } from './league';
+export { runDailyMatches } from './runner';

--- a/functions/src/league.ts
+++ b/functions/src/league.ts
@@ -1,0 +1,100 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import { generateRoundRobinFixtures, getNextStartDate } from './utils/schedule';
+
+admin.initializeApp();
+const db = admin.firestore();
+
+export const assignTeamToLeague = functions.https.onCall(async (data, context) => {
+  const teamId: string = data.teamId;
+  if (!teamId) {
+    throw new functions.https.HttpsError('invalid-argument', 'teamId required');
+  }
+  const leagueSnap = await db.runTransaction(async (tx) => {
+    // ensure team not already in a league
+    const existing = await tx.get(
+      db.collectionGroup('teams').where('teamId', '==', teamId).limit(1)
+    );
+    if (!existing.empty) {
+      return existing.docs[0].ref.parent.parent!; // league ref
+    }
+    // find oldest forming league
+    const forming = await tx.get(
+      db
+        .collection('leagues')
+        .where('state', '==', 'forming')
+        .orderBy('createdAt', 'asc')
+        .limit(1)
+    );
+    let leagueRef: FirebaseFirestore.DocumentReference;
+    if (forming.empty) {
+      leagueRef = db.collection('leagues').doc();
+      tx.set(leagueRef, {
+        name: `League ${leagueRef.id}`,
+        season: 1,
+        capacity: 22,
+        timezone: 'Europe/Istanbul',
+        state: 'forming',
+        rounds: 21,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    } else {
+      leagueRef = forming.docs[0].ref;
+    }
+    const teamsCol = leagueRef.collection('teams');
+    const teamsSnap = await tx.get(teamsCol);
+    if (teamsSnap.docs.some((d) => d.id === teamId)) {
+      return leagueRef;
+    }
+    tx.set(teamsCol.doc(teamId), {
+      teamId,
+      joinedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    const count = teamsSnap.size + 1;
+    if (count === 22) {
+      const startDate = getNextStartDate();
+      tx.update(leagueRef, {
+        state: 'scheduled',
+        startDate: admin.firestore.Timestamp.fromDate(startDate),
+      });
+    }
+    return leagueRef;
+  });
+
+  // generate fixtures if scheduled
+  const leagueData = (await leagueSnap.get()).data() as any;
+  if (leagueData.state === 'scheduled') {
+    await generateFixturesForLeague(leagueSnap.id);
+  }
+  return { leagueId: leagueSnap.id, state: leagueData.state };
+});
+
+async function generateFixturesForLeague(leagueId: string) {
+  const leagueRef = db.collection('leagues').doc(leagueId);
+  const leagueSnap = await leagueRef.get();
+  const league = leagueSnap.data() as any;
+  const teamsSnap = await leagueRef.collection('teams').get();
+  const teamIds = teamsSnap.docs.map((d) => d.id);
+  const fixtures = generateRoundRobinFixtures(teamIds);
+  const batch = db.batch();
+  fixtures.forEach((m) => {
+    const date = new Date(league.startDate.toDate().getTime());
+    date.setUTCDate(date.getUTCDate() + (m.round - 1));
+    const ref = leagueRef.collection('fixtures').doc();
+    batch.set(ref, {
+      round: m.round,
+      date: admin.firestore.Timestamp.fromDate(date),
+      homeTeamId: m.homeTeamId,
+      awayTeamId: m.awayTeamId,
+      participants: [m.homeTeamId, m.awayTeamId],
+      status: 'scheduled',
+      score: null,
+    });
+  });
+  await batch.commit();
+}
+
+export const generateRoundRobinFixturesFn = functions.https.onCall(async (data) => {
+  await generateFixturesForLeague(data.leagueId);
+  return true;
+});

--- a/functions/src/runner.ts
+++ b/functions/src/runner.ts
@@ -1,0 +1,53 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+const db = admin.firestore();
+
+export const runDailyMatches = functions.pubsub
+  .schedule('0 19 * * *')
+  .timeZone('Europe/Istanbul')
+  .onRun(async () => {
+    const now = admin.firestore.Timestamp.now();
+    const snap = await db
+      .collectionGroup('fixtures')
+      .where('status', '==', 'scheduled')
+      .where('date', '<=', now)
+      .get();
+    await Promise.all(snap.docs.map(processMatch));
+  });
+
+async function processMatch(doc: FirebaseFirestore.QueryDocumentSnapshot) {
+  const data = doc.data() as any;
+  const leagueRef = doc.ref.parent.parent!;
+  const homeRef = leagueRef.collection('standings').doc(data.homeTeamId);
+  const awayRef = leagueRef.collection('standings').doc(data.awayTeamId);
+  const homeScore = Math.floor(Math.random() * 5);
+  const awayScore = Math.floor(Math.random() * 5);
+  await db.runTransaction(async (tx) => {
+    tx.update(doc.ref, {
+      status: 'played',
+      score: { home: homeScore, away: awayScore },
+    });
+    const homeSnap = await tx.get(homeRef);
+    const awaySnap = await tx.get(awayRef);
+    const hs = homeSnap.exists ? (homeSnap.data() as any) : {
+      teamId: data.homeTeamId,
+      name: '',
+      P: 0, W: 0, D: 0, L: 0, GF: 0, GA: 0, GD: 0, Pts: 0,
+    };
+    const as = awaySnap.exists ? (awaySnap.data() as any) : {
+      teamId: data.awayTeamId,
+      name: '',
+      P: 0, W: 0, D: 0, L: 0, GF: 0, GA: 0, GD: 0, Pts: 0,
+    };
+    hs.P++; as.P++;
+    hs.GF += homeScore; hs.GA += awayScore;
+    as.GF += awayScore; as.GA += homeScore;
+    hs.GD = hs.GF - hs.GA; as.GD = as.GF - as.GA;
+    if (homeScore > awayScore) { hs.W++; as.L++; hs.Pts += 3; }
+    else if (homeScore < awayScore) { as.W++; hs.L++; as.Pts += 3; }
+    else { hs.D++; as.D++; hs.Pts++; as.Pts++; }
+    tx.set(homeRef, hs, { merge: true });
+    tx.set(awayRef, as, { merge: true });
+  });
+}

--- a/functions/src/utils/schedule.test.ts
+++ b/functions/src/utils/schedule.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { generateRoundRobinFixtures } from './schedule';
+
+describe('generateRoundRobinFixtures', () => {
+  it('produces 21 rounds with 11 matches each for 22 teams', () => {
+    const teams = Array.from({ length: 22 }, (_, i) => `t${i + 1}`);
+    const fixtures = generateRoundRobinFixtures(teams);
+    const rounds = new Map<number, number>();
+    fixtures.forEach(f => rounds.set(f.round, (rounds.get(f.round) || 0) + 1));
+    expect(rounds.size).toBe(21);
+    rounds.forEach(count => expect(count).toBe(11));
+    // Each team plays once per round
+    for (let r = 1; r <= 21; r++) {
+      const teamsInRound = new Set<string>();
+      fixtures.filter(f => f.round === r).forEach(f => {
+        teamsInRound.add(f.homeTeamId);
+        teamsInRound.add(f.awayTeamId);
+      });
+      expect(teamsInRound.size).toBe(22);
+    }
+  });
+});

--- a/functions/src/utils/schedule.ts
+++ b/functions/src/utils/schedule.ts
@@ -1,0 +1,58 @@
+export interface MatchPair {
+  round: number;
+  homeTeamId: string;
+  awayTeamId: string;
+}
+
+// Generates round robin fixtures using Berger algorithm for even number of teams
+export function generateRoundRobinFixtures(teamIds: string[]): MatchPair[] {
+  const n = teamIds.length;
+  if (n % 2 !== 0) {
+    throw new Error('Team count must be even');
+  }
+  const rounds = n - 1;
+  const half = n / 2;
+  const teams = [...teamIds];
+  const fixtures: MatchPair[] = [];
+
+  for (let round = 0; round < rounds; round++) {
+    for (let i = 0; i < half; i++) {
+      const homeIdx = (round + i) % (n - 1);
+      const awayIdx = (n - 1 - i + round) % (n - 1);
+      let home = teams[homeIdx];
+      let away = teams[awayIdx];
+      if (i === 0) {
+        away = teams[n - 1];
+      }
+      // alternate home/away per round
+      if (round % 2 === 1) {
+        const tmp = home;
+        home = away;
+        away = tmp;
+      }
+      fixtures.push({ round: round + 1, homeTeamId: home, awayTeamId: away });
+    }
+  }
+  return fixtures;
+}
+
+// Returns a Date for tomorrow 19:00 in Europe/Istanbul
+export function getNextStartDate(): Date {
+  const now = new Date();
+  const tz = 'Europe/Istanbul';
+  // current time in TZ
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = fmt.formatToParts(now);
+  const year = Number(parts.find(p => p.type === 'year')?.value);
+  const month = Number(parts.find(p => p.type === 'month')?.value);
+  const day = Number(parts.find(p => p.type === 'day')?.value) + 1; // tomorrow
+  const local = new Date(Date.UTC(year, month - 1, day, 19, 0, 0));
+  // convert from TZ to UTC
+  const tzOffset = new Date(local.toLocaleString('en-US', { timeZone: tz })).getTime() - local.getTime();
+  return new Date(local.getTime() - tzOffset);
+}

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "lib",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import TeamPlanning from './pages/TeamPlanning';
 import Youth from './pages/Youth';
 import Fixtures from './pages/Fixtures';
 import Leagues from './pages/Leagues';
+import LeagueDetail from './pages/LeagueDetail';
 import Training from './pages/Training';
 import MatchPreview from './pages/MatchPreview';
 import MatchSimulation from './pages/MatchSimulation';
@@ -41,6 +42,7 @@ const AppContent = () => {
         <Route path="/youth" element={<Youth />} />
         <Route path="/fixtures" element={<Fixtures />} />
         <Route path="/leagues" element={<Leagues />} />
+        <Route path="/leagues/:leagueId" element={<LeagueDetail />} />
         <Route path="/training" element={<Training />} />
         <Route path="/match-preview" element={<MatchPreview />} />
         <Route path="/match-simulation" element={<MatchSimulation />} />

--- a/src/pages/Fixtures.tsx
+++ b/src/pages/Fixtures.tsx
@@ -1,178 +1,63 @@
-import React, { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { upcomingMatches } from '@/lib/data';
-import { Match } from '@/types';
-import { Calendar, MapPin, Trophy, Filter } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-const completedMatches: Match[] = [
-  {
-    id: 'c1',
-    opponent: 'Beşiktaş',
-    opponentLogo: '🦅',
-    date: '2025-08-10',
-    time: '20:00',
-    venue: 'home',
-    status: 'completed',
-    score: { home: 2, away: 1 },
-    competition: 'Süper Lig'
-  },
-  {
-    id: 'c2',
-    opponent: 'Trabzonspor',
-    opponentLogo: '🔴',
-    date: '2025-08-05',
-    time: '19:00',
-    venue: 'away',
-    status: 'completed',
-    score: { home: 1, away: 1 },
-    competition: 'Süper Lig'
-  },
-];
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
+import { listenMyLeague, getFixturesForTeam } from '@/services/leagues';
+import type { Fixture } from '@/types';
 
 export default function Fixtures() {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState('upcoming');
+  const { user } = useAuth();
+  const [fixtures, setFixtures] = useState<Fixture[]>([]);
 
-  const MatchCard = ({ match }: { match: Match }) => (
-    <Card className="hover:shadow-md transition-shadow cursor-pointer">
-      <CardContent className="p-4">
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-2">
-            <Badge variant="outline" className="text-xs">
-              {match.competition}
-            </Badge>
-            <Badge variant={match.venue === 'home' ? 'default' : 'secondary'} className="text-xs">
-              {match.venue === 'home' ? 'İç Saha' : 'Deplasman'}
-            </Badge>
-          </div>
-          <div className="text-right text-sm text-muted-foreground">
-            <div>{new Date(match.date).toLocaleDateString('tr-TR')}</div>
-            <div>{match.time}</div>
-          </div>
-        </div>
-        
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="text-2xl">{match.venue === 'home' ? '⚽' : match.opponentLogo}</div>
-            <div>
-              <div className="font-semibold">
-                {match.venue === 'home' ? 'Takımım' : match.opponent}
-              </div>
-              <div className="text-sm text-muted-foreground flex items-center gap-1">
-                <MapPin className="h-3 w-3" />
-                {match.venue === 'home' ? 'Ev Sahipliği' : 'Deplasman'}
-              </div>
-            </div>
-          </div>
+  useEffect(() => {
+    if (!user) return;
+    const unsub = listenMyLeague(user.uid, async (league) => {
+      if (!league) {
+        setFixtures([]);
+        return;
+      }
+      const list = await getFixturesForTeam(league.id, user.uid);
+      setFixtures(list);
+    });
+    return unsub;
+  }, [user]);
 
-          <div className="text-center">
-            <div className="text-2xl font-bold">VS</div>
-          </div>
-
-          <div className="flex items-center gap-3">
-            <div className="text-right">
-              <div className="font-semibold">
-                {match.venue === 'home' ? match.opponent : 'Takımım'}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {match.status === 'completed' && match.score ? (
-                  <span className="font-semibold text-foreground">
-                    {match.venue === 'home' 
-                      ? `${match.score.home}-${match.score.away}`
-                      : `${match.score.away}-${match.score.home}`
-                    }
-                  </span>
-                ) : (
-                  <Badge variant="outline" className="text-xs">
-                    {match.status === 'scheduled' ? 'Planlandı' : 'Canlı'}
-                  </Badge>
-                )}
-              </div>
-            </div>
-            <div className="text-2xl">{match.venue === 'home' ? match.opponentLogo : '⚽'}</div>
-          </div>
-        </div>
-
-        {match.status === 'scheduled' && (
-          <div className="mt-3 flex gap-2">
-            <Button size="sm" variant="outline" className="flex-1">
-              Detaylar
-            </Button>
-            <Button size="sm" className="flex-1">
-              Maç Önizleme
-            </Button>
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
+  const formatDate = (d: Date | { toDate: () => Date }) => {
+    const date = d instanceof Date ? d : d.toDate();
+    return date.toLocaleString('tr-TR', { timeZone: 'Europe/Istanbul', hour12: false });
+  };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 dark:from-green-950 dark:via-emerald-950 dark:to-teal-950">
-      {/* Header */}
-      <div className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-b p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Button variant="ghost" onClick={() => navigate('/')}>←</Button>
-            <h1 className="text-xl font-bold">Fikstür</h1>
-          </div>
-          <Button variant="outline" size="sm">
-            <Filter className="h-4 w-4 mr-2" />
-            Filtre
-          </Button>
-        </div>
+    <div className="p-4">
+      <div className="flex items-center justify-between mb-4">
+        <Button variant="ghost" onClick={() => navigate('/')}>←</Button>
+        <h1 className="text-xl font-bold">Fikstür</h1>
       </div>
-
-      <div className="p-4">
-        {/* Quick Stats */}
-        <div className="grid grid-cols-3 gap-4 mb-6">
-          <Card>
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-blue-600">{upcomingMatches.length}</div>
-              <div className="text-sm text-muted-foreground">Yaklaşan</div>
+      <div className="space-y-2">
+        {fixtures.map((m) => (
+          <Card key={m.id} data-testid={`fixture-row-${m.id}`}>
+            <CardContent className="p-4 flex items-center justify-between">
+              <div>
+                <div className="font-medium">Round {m.round}</div>
+                <div className="text-sm text-muted-foreground">{formatDate(m.date)}</div>
+              </div>
+              <div className="text-center">
+                <div>{m.homeTeamId} vs {m.awayTeamId}</div>
+                {m.status === 'played' && m.score && (
+                  <div className="font-bold">
+                    {m.score.home}-{m.score.away}
+                  </div>
+                )}
+                {m.status !== 'played' && (
+                  <Badge>{m.status}</Badge>
+                )}
+              </div>
             </CardContent>
           </Card>
-          <Card>
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-green-600">5</div>
-              <div className="text-sm text-muted-foreground">Galibiyet</div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-purple-600">2</div>
-              <div className="text-sm text-muted-foreground">Beraberlik</div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Matches */}
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="upcoming">
-              Yaklaşan Maçlar
-            </TabsTrigger>
-            <TabsTrigger value="completed">
-              Tamamlanan
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="upcoming" className="space-y-4 mt-4">
-            {upcomingMatches.map(match => (
-              <MatchCard key={match.id} match={match} />
-            ))}
-          </TabsContent>
-
-          <TabsContent value="completed" className="space-y-4 mt-4">
-            {completedMatches.map(match => (
-              <MatchCard key={match.id} match={match} />
-            ))}
-          </TabsContent>
-        </Tabs>
+        ))}
       </div>
     </div>
   );

--- a/src/pages/LeagueDetail.tsx
+++ b/src/pages/LeagueDetail.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { listenStandings } from '@/services/leagues';
+import type { Standing } from '@/types';
+import { Card, CardContent } from '@/components/ui/card';
+
+export default function LeagueDetail() {
+  const { leagueId } = useParams();
+  const [rows, setRows] = useState<Standing[]>([]);
+
+  useEffect(() => {
+    if (!leagueId) return;
+    const unsub = listenStandings(leagueId, setRows);
+    return unsub;
+  }, [leagueId]);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Lig Detayı</h1>
+      <Card>
+        <CardContent className="p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <th className="p-2">Takım</th>
+                <th className="p-2">P</th>
+                <th className="p-2">W</th>
+                <th className="p-2">D</th>
+                <th className="p-2">L</th>
+                <th className="p-2">GF</th>
+                <th className="p-2">GA</th>
+                <th className="p-2">GD</th>
+                <th className="p-2">Pts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.teamId} data-testid={`standings-row-${r.teamId}`} className="border-b">
+                  <td className="p-2">{r.name}</td>
+                  <td className="p-2">{r.P}</td>
+                  <td className="p-2">{r.W}</td>
+                  <td className="p-2">{r.D}</td>
+                  <td className="p-2">{r.L}</td>
+                  <td className="p-2">{r.GF}</td>
+                  <td className="p-2">{r.GA}</td>
+                  <td className="p-2">{r.GD}</td>
+                  <td className="p-2">{r.Pts}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/Leagues.tsx
+++ b/src/pages/Leagues.tsx
@@ -1,164 +1,40 @@
-import React, { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { leagueTable } from '@/lib/data';
-import { Trophy, TrendingUp, TrendingDown } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { listLeagues } from '@/services/leagues';
+import type { League } from '@/types';
 
 export default function Leagues() {
+  const [leagues, setLeagues] = useState<League[]>([]);
   const navigate = useNavigate();
-  const [selectedLeague, setSelectedLeague] = useState('super-lig');
 
-  const getFormBadge = (result: string) => {
-    switch (result) {
-      case 'W': return <Badge className="w-6 h-6 p-0 bg-green-500 text-white">G</Badge>;
-      case 'D': return <Badge className="w-6 h-6 p-0 bg-yellow-500 text-white">B</Badge>;
-      case 'L': return <Badge className="w-6 h-6 p-0 bg-red-500 text-white">M</Badge>;
-      default: return <Badge className="w-6 h-6 p-0 bg-gray-500 text-white">-</Badge>;
-    }
-  };
-
-  const getPositionTrend = (position: number) => {
-    if (position <= 4) return <TrendingUp className="h-4 w-4 text-green-500" />;
-    if (position >= 18) return <TrendingDown className="h-4 w-4 text-red-500" />;
-    return null;
-  };
+  useEffect(() => {
+    listLeagues().then(setLeagues);
+  }, []);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 dark:from-green-950 dark:via-emerald-950 dark:to-teal-950">
-      {/* Header */}
-      <div className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-b p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Button variant="ghost" onClick={() => navigate('/')}>←</Button>
-            <h1 className="text-xl font-bold">Ligler</h1>
-          </div>
-        </div>
-      </div>
-
-      <div className="p-4">
-        {/* League Selector */}
-        <Tabs value={selectedLeague} onValueChange={setSelectedLeague} className="mb-6">
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="super-lig">Süper Lig</TabsTrigger>
-            <TabsTrigger value="champions">Şampiyonlar Ligi</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="super-lig">
-            {/* My Team Position */}
-            <Card className="mb-6">
-              <CardContent className="p-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="text-2xl">⚽</div>
-                    <div>
-                      <div className="font-bold">Takımım</div>
-                      <div className="text-sm text-muted-foreground">3. sırada</div>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <div className="text-2xl font-bold text-blue-600">15</div>
-                    <div className="text-sm text-muted-foreground">Puan</div>
-                  </div>
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Ligler</h1>
+      <div className="space-y-2">
+        {leagues.map((l) => (
+          <Card
+            key={l.id}
+            data-testid={`league-row-${l.id}`}
+            className="cursor-pointer"
+            onClick={() => navigate(`/leagues/${l.id}`)}
+          >
+            <CardContent className="flex items-center justify-between p-4">
+              <div>
+                <div className="font-semibold">{l.name}</div>
+                <div className="text-sm text-muted-foreground">
+                  Sezon {l.season} - {l.teamCount ?? 0}/{l.capacity}
                 </div>
-              </CardContent>
-            </Card>
-
-            {/* League Table */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Trophy className="h-5 w-5" />
-                  Süper Lig Puan Durumu
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-1">
-                  {/* Header */}
-                  <div className="grid grid-cols-12 gap-2 p-2 text-xs font-semibold text-muted-foreground border-b">
-                    <div className="col-span-1">#</div>
-                    <div className="col-span-4">Takım</div>
-                    <div className="col-span-1">O</div>
-                    <div className="col-span-1">P</div>
-                    <div className="col-span-2">AV</div>
-                    <div className="col-span-3">Form</div>
-                  </div>
-
-                  {/* Teams */}
-                  {leagueTable.map((team, index) => (
-                    <div 
-                      key={team.name}
-                      className={`grid grid-cols-12 gap-2 p-2 rounded text-sm hover:bg-muted/50 ${
-                        team.name === 'Takımım' ? 'bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800' : ''
-                      }`}
-                    >
-                      <div className="col-span-1 flex items-center gap-1">
-                        <span className="font-semibold">{team.position}</span>
-                        {getPositionTrend(team.position)}
-                      </div>
-                      
-                      <div className="col-span-4 flex items-center gap-2">
-                        <span className="text-lg">{team.logo}</span>
-                        <span className="font-medium truncate">{team.name}</span>
-                      </div>
-                      
-                      <div className="col-span-1 text-center">{team.played}</div>
-                      <div className="col-span-1 text-center font-semibold">{team.points}</div>
-                      <div className="col-span-2 text-center">
-                        <span className={team.goalDifference >= 0 ? 'text-green-600' : 'text-red-600'}>
-                          {team.goalDifference > 0 ? '+' : ''}{team.goalDifference}
-                        </span>
-                      </div>
-                      
-                      <div className="col-span-3 flex gap-1">
-                        {team.form.split('').map((result, i) => (
-                          <div key={i}>{getFormBadge(result)}</div>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-
-                {/* Legend */}
-                <div className="mt-4 pt-4 border-t">
-                  <div className="grid grid-cols-2 gap-4 text-xs text-muted-foreground">
-                    <div>
-                      <div className="flex items-center gap-2 mb-1">
-                        <div className="w-3 h-3 bg-green-100 border-l-4 border-green-500"></div>
-                        <span>Şampiyonlar Ligi (1-4)</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <div className="w-3 h-3 bg-blue-100 border-l-4 border-blue-500"></div>
-                        <span>Avrupa Ligi (5-6)</span>
-                      </div>
-                    </div>
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <div className="w-3 h-3 bg-red-100 border-l-4 border-red-500"></div>
-                        <span>Küme Düşme (18-20)</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="champions">
-            <Card>
-              <CardContent className="p-8 text-center">
-                <div className="text-4xl mb-4">🏆</div>
-                <h3 className="font-semibold mb-2">Şampiyonlar Ligi</h3>
-                <p className="text-muted-foreground text-sm">
-                  Henüz Şampiyonlar Ligi'ne katılmaya hak kazanmadınız. 
-                  Süper Lig'de ilk 4'e girerek Avrupa'ya açılın!
-                </p>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+              </div>
+              <Badge>{l.state}</Badge>
+            </CardContent>
+          </Card>
+        ))}
       </div>
     </div>
   );

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore, enableIndexedDbPersistence } from "firebase/firestore";
+import { getFunctions } from "firebase/functions";
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -17,5 +18,6 @@ console.log(
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+export const functions = getFunctions(app);
 enableIndexedDbPersistence(db).catch(() => {});
 

--- a/src/services/leagues.ts
+++ b/src/services/leagues.ts
@@ -1,0 +1,76 @@
+import {
+  collection,
+  collectionGroup,
+  getDocs,
+  onSnapshot,
+  orderBy,
+  query,
+  where,
+  limit,
+  Unsubscribe,
+} from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import { db, functions } from './firebase';
+import type { League, Fixture, Standing } from '@/types';
+
+export async function requestJoinLeague(teamId: string) {
+  const fn = httpsCallable(functions, 'assignTeamToLeague');
+  const res = await fn({ teamId });
+  return res.data as { leagueId: string; state: string };
+}
+
+export function listenMyLeague(teamId: string, cb: (league: League | null) => void): Unsubscribe {
+  const teamsQ = query(collectionGroup(db, 'teams'), where('teamId', '==', teamId), limit(1));
+  let unsubLeague: Unsubscribe | null = null;
+  const unsubTeams = onSnapshot(teamsQ, (snap) => {
+    if (unsubLeague) unsubLeague();
+    if (snap.empty) {
+      cb(null);
+      return;
+    }
+    const leagueRef = snap.docs[0].ref.parent.parent!;
+    unsubLeague = onSnapshot(leagueRef, (ls) => {
+      cb({ id: ls.id, ...(ls.data() as Omit<League, 'id'>) });
+    });
+  });
+  return () => {
+    if (unsubLeague) unsubLeague();
+    unsubTeams();
+  };
+}
+
+export async function getFixturesForTeam(leagueId: string, teamId: string): Promise<Fixture[]> {
+  const col = collection(db, 'leagues', leagueId, 'fixtures');
+  const q = query(col, where('participants', 'array-contains', teamId), orderBy('date'));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Fixture, 'id'>) }));
+}
+
+export function listenStandings(leagueId: string, cb: (rows: Standing[]) => void): Unsubscribe {
+  const col = collection(db, 'leagues', leagueId, 'standings');
+  const q = query(col, orderBy('Pts', 'desc'), orderBy('GD', 'desc'), orderBy('GF', 'desc'));
+  return onSnapshot(q, (snap) => {
+    cb(snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Standing, 'id'>) })));
+  });
+}
+
+export async function listLeagues(): Promise<League[]> {
+  const snap = await getDocs(collection(db, 'leagues'));
+  const leagues: League[] = [];
+  for (const d of snap.docs) {
+    const teams = await getDocs(collection(d.ref, 'teams'));
+    leagues.push({
+      id: d.id,
+      teamCount: teams.size,
+      ...(d.data() as Omit<League, 'id' | 'teamCount'>),
+    });
+  }
+  return leagues;
+}
+
+export async function listLeagueStandings(leagueId: string): Promise<Standing[]> {
+  const col = collection(db, 'leagues', leagueId, 'standings');
+  const q = query(col, orderBy('Pts', 'desc'), orderBy('GD', 'desc'), orderBy('GF', 'desc'));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Standing, 'id'>) }));
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,6 +84,36 @@ export interface Team {
   goalDifference: number;
 }
 
+export interface League {
+  id: string;
+  name: string;
+  season: number;
+  capacity: number;
+  timezone: string;
+  state: 'forming' | 'scheduled' | 'active' | 'completed';
+  startDate?: unknown;
+  rounds: number;
+  teamCount?: number;
+}
+
+export interface Fixture {
+  id: string;
+  round: number;
+  date: unknown;
+  homeTeamId: string;
+  awayTeamId: string;
+  participants: string[];
+  status: 'scheduled' | 'in_progress' | 'played';
+  score: { home: number; away: number } | null;
+}
+
+export interface Standing {
+  id: string;
+  teamId: string;
+  name: string;
+  P: number; W: number; D: number; L: number; GF: number; GA: number; GD: number; Pts: number;
+}
+
 export interface Training {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- implement Berger-based round-robin scheduling and start date helper
- add Cloud Functions for league assignment, fixture generation, and daily match runner
- secure leagues, fixtures, and standings in Firestore and add composite indexes
- expose league/fixture services and screens on the frontend

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfef73044832ab91e8031ed115183