### PR TITLE
fix: correct user id in fixtures query

### DIFF
--- a/src/pages/Fixtures.tsx
+++ b/src/pages/Fixtures.tsx
@@ -14,12 +14,12 @@ export default function Fixtures() {
 
   useEffect(() => {
     if (!user) return;
-    const unsub = listenMyLeague(user.uid, async (league) => {
+    const unsub = listenMyLeague(user.id, async (league) => {
       if (!league) {
         setFixtures([]);
         return;
       }
-      const list = await getFixturesForTeam(league.id, user.uid);
+      const list = await getFixturesForTeam(league.id, user.id);
       setFixtures(list);
     });
     return unsub;


### PR DESCRIPTION
## Summary
- use `user.id` when listening for leagues and fetching fixtures

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae01596898832a9c412b638d63ae98