### PR TITLE
feat: list current and other leagues

### DIFF
--- a/src/pages/Leagues.tsx
+++ b/src/pages/Leagues.tsx
@@ -2,40 +2,78 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { listLeagues } from '@/services/leagues';
+import { useAuth } from '@/contexts/AuthContext';
+import { listLeagues, listenMyLeague } from '@/services/leagues';
 import type { League } from '@/types';
 
 export default function Leagues() {
-  const [leagues, setLeagues] = useState<League[]>([]);
   const navigate = useNavigate();
+  const { user } = useAuth();
+  const [leagues, setLeagues] = useState<League[]>([]);
+  const [myLeagueId, setMyLeagueId] = useState<string | null>(null);
 
   useEffect(() => {
     listLeagues().then(setLeagues);
   }, []);
 
+  useEffect(() => {
+    if (!user) return;
+    const unsub = listenMyLeague(user.id, (league) => {
+      setMyLeagueId(league?.id ?? null);
+    });
+    return unsub;
+  }, [user]);
+
+  const myLeague = leagues.find((l) => l.id === myLeagueId) || null;
+  const otherLeagues = leagues.filter((l) => l.id !== myLeagueId);
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Ligler</h1>
-      <div className="space-y-2">
-        {leagues.map((l) => (
+      {myLeague && (
+        <div className="mb-6">
+          <h2 className="font-semibold mb-2">Takımının Ligi</h2>
           <Card
-            key={l.id}
-            data-testid={`league-row-${l.id}`}
+            key={myLeague.id}
+            data-testid={`league-row-${myLeague.id}`}
             className="cursor-pointer"
-            onClick={() => navigate(`/leagues/${l.id}`)}
+            onClick={() => navigate(`/leagues/${myLeague.id}`)}
           >
             <CardContent className="flex items-center justify-between p-4">
               <div>
-                <div className="font-semibold">{l.name}</div>
+                <div className="font-semibold">{myLeague.name}</div>
                 <div className="text-sm text-muted-foreground">
-                  Sezon {l.season} - {l.teamCount ?? 0}/{l.capacity}
+                  Sezon {myLeague.season} - {myLeague.teamCount ?? 0}/{myLeague.capacity}
                 </div>
               </div>
-              <Badge>{l.state}</Badge>
+              <Badge>{myLeague.state}</Badge>
             </CardContent>
           </Card>
-        ))}
-      </div>
+        </div>
+      )}
+      {otherLeagues.length > 0 && (
+        <div className="space-y-2">
+          {myLeague && <h2 className="font-semibold mb-2">Diğer Ligler</h2>}
+          {otherLeagues.map((l) => (
+            <Card
+              key={l.id}
+              data-testid={`league-row-${l.id}`}
+              className="cursor-pointer"
+              onClick={() => navigate(`/leagues/${l.id}`)}
+            >
+              <CardContent className="flex items-center justify-between p-4">
+                <div>
+                  <div className="font-semibold">{l.name}</div>
+                  <div className="text-sm text-muted-foreground">
+                    Sezon {l.season} - {l.teamCount ?? 0}/{l.capacity}
+                  </div>
+                </div>
+                <Badge>{l.state}</Badge>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show the authenticated team's league and list other leagues separately on league page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae02b636dc832abbe60d527481259d