### PR TITLE
Use documentId for league team lookup to avoid Firestore index requirement

### DIFF
--- a/functions/src/league.ts
+++ b/functions/src/league.ts
@@ -13,7 +13,10 @@ export const assignTeamToLeague = functions.https.onCall(async (data, context) =
   const leagueSnap = await db.runTransaction(async (tx) => {
     // ensure team not already in a league
     const existing = await tx.get(
-      db.collectionGroup('teams').where('teamId', '==', teamId).limit(1)
+      db
+        .collectionGroup('teams')
+        .where(admin.firestore.FieldPath.documentId(), '==', teamId)
+        .limit(1)
     );
     if (!existing.empty) {
       return existing.docs[0].ref.parent.parent!; // league ref

--- a/src/services/leagues.ts
+++ b/src/services/leagues.ts
@@ -6,6 +6,7 @@ import {
   orderBy,
   query,
   where,
+  documentId,
   limit,
   Unsubscribe,
 } from 'firebase/firestore';
@@ -20,7 +21,11 @@ export async function requestJoinLeague(teamId: string) {
 }
 
 export function listenMyLeague(teamId: string, cb: (league: League | null) => void): Unsubscribe {
-  const teamsQ = query(collectionGroup(db, 'teams'), where('teamId', '==', teamId), limit(1));
+  const teamsQ = query(
+    collectionGroup(db, 'teams'),
+    where(documentId(), '==', teamId),
+    limit(1)
+  );
   let unsubLeague: Unsubscribe | null = null;
   const unsubTeams = onSnapshot(teamsQ, (snap) => {
     if (unsubLeague) unsubLeague();


### PR DESCRIPTION
## Summary
- Query league teams by document ID rather than a `teamId` field to remove Firestore index requirements.
- Update client and Cloud Function queries accordingly.

## Testing
- `pnpm lint`
- `pnpm test`
- `npm --prefix functions run build` *(fails: Cannot find module 'firebase-admin', install attempt 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae03f2b928832a82e171685ba9cc28