### PR TITLE
fix: use teamId field for league query

### DIFF
--- a/functions/src/league.ts
+++ b/functions/src/league.ts
@@ -15,7 +15,7 @@ export const assignTeamToLeague = functions.https.onCall(async (data, context) =
     const existing = await tx.get(
       db
         .collectionGroup('teams')
-        .where(admin.firestore.FieldPath.documentId(), '==', teamId)
+        .where('teamId', '==', teamId)
         .limit(1)
     );
     if (!existing.empty) {

--- a/src/services/leagues.ts
+++ b/src/services/leagues.ts
@@ -6,7 +6,6 @@ import {
   orderBy,
   query,
   where,
-  documentId,
   limit,
   Unsubscribe,
 } from 'firebase/firestore';
@@ -23,7 +22,7 @@ export async function requestJoinLeague(teamId: string) {
 export function listenMyLeague(teamId: string, cb: (league: League | null) => void): Unsubscribe {
   const teamsQ = query(
     collectionGroup(db, 'teams'),
-    where(documentId(), '==', teamId),
+    where('teamId', '==', teamId),
     limit(1)
   );
   let unsubLeague: Unsubscribe | null = null;


### PR DESCRIPTION
## Summary
- query leagues by teamId field instead of documentId
- mirror change in Cloud Function league assignment

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae056692a0832a8e301da2388426fe