### PR TITLE
feat: show empty league message

### DIFF
--- a/src/pages/Leagues.tsx
+++ b/src/pages/Leagues.tsx
@@ -30,6 +30,14 @@ export default function Leagues() {
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Ligler</h1>
+      {leagues.length === 0 && (
+        <p
+          data-testid="no-leagues-message"
+          className="text-sm text-muted-foreground"
+        >
+          Henüz lig oluşturulmamış.
+        </p>
+      )}
       {myLeague && (
         <div className="mb-6">
           <h2 className="font-semibold mb-2">Takımının Ligi</h2>


### PR DESCRIPTION
## Summary
- show a helpful message when no leagues exist on the leagues page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0863b044832a8d4771a7646240cd