### PR TITLE
Auto assign teams to leagues and show league teams

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,2 +1,6 @@
-export { assignTeamToLeague, generateRoundRobinFixturesFn } from './league';
+export {
+  assignTeamToLeague,
+  assignAllTeamsToLeagues,
+  generateRoundRobinFixturesFn,
+} from './league';
 export { runDailyMatches } from './runner';

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ import { User } from '@/types';
 import { auth } from '@/services/firebase';
 import { signIn, signUp, signOutUser } from '@/services/auth';
 import { createInitialTeam, getTeam } from '@/services/team';
+import { requestJoinLeague } from '@/services/leagues';
 import { generateRandomName } from '@/lib/names';
 
 interface AuthContextType {
@@ -54,6 +55,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         });
         if (!team) {
           await createInitialTeam(firebaseUser.uid, teamName, username);
+          await requestJoinLeague(firebaseUser.uid);
         }
       } else {
         setUser(null);
@@ -83,6 +85,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         const managerName = generateRandomName();
         await updateProfile(cred.user, { displayName: teamName });
         await createInitialTeam(cred.user.uid, teamName, managerName);
+        await requestJoinLeague(cred.user.uid);
       }
     } finally {
       setIsLoading(false);

--- a/src/pages/Leagues.tsx
+++ b/src/pages/Leagues.tsx
@@ -53,6 +53,11 @@ export default function Leagues() {
                 <div className="text-sm text-muted-foreground">
                   Sezon {myLeague.season} - {myLeague.teamCount ?? 0}/{myLeague.capacity}
                 </div>
+                {myLeague.teams && myLeague.teams.length > 0 && (
+                  <div className="text-xs text-muted-foreground mt-1">
+                    Takımlar: {myLeague.teams.map((t) => t.name).join(', ')}
+                  </div>
+                )}
               </div>
               <Badge>{myLeague.state}</Badge>
             </CardContent>
@@ -75,6 +80,11 @@ export default function Leagues() {
                   <div className="text-sm text-muted-foreground">
                     Sezon {l.season} - {l.teamCount ?? 0}/{l.capacity}
                   </div>
+                  {l.teams && l.teams.length > 0 && (
+                    <div className="text-xs text-muted-foreground mt-1">
+                      Takımlar: {l.teams.map((t) => t.name).join(', ')}
+                    </div>
+                  )}
                 </div>
                 <Badge>{l.state}</Badge>
               </CardContent>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,6 +94,7 @@ export interface League {
   startDate?: unknown;
   rounds: number;
   teamCount?: number;
+  teams?: { id: string; name: string }[];
 }
 
 export interface Fixture {


### PR DESCRIPTION
## Summary
- add Firebase functions to auto-assign teams into leagues and schedule fixtures when full
- join new teams to leagues during registration and fetch league team names
- display each league's teams on the leagues page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae1b3dadf8832ab8f25761dce87428