### PR TITLE
Show teams before league start

### DIFF
--- a/src/pages/LeagueDetailPage.tsx
+++ b/src/pages/LeagueDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { listenStandings } from '@/services/leagues';
+import { listenStandings, getLeagueTeams } from '@/services/leagues';
 import type { Standing } from '@/types';
 import { Card, CardContent } from '@/components/ui/card';
 
@@ -10,7 +10,28 @@ export default function LeagueDetailPage() {
 
   useEffect(() => {
     if (!leagueId) return;
-    const unsub = listenStandings(leagueId, setRows);
+    const unsub = listenStandings(leagueId, async (sRows) => {
+      if (sRows.length === 0) {
+        const teams = await getLeagueTeams(leagueId);
+        setRows(
+          teams.map((t) => ({
+            id: t.id,
+            teamId: t.id,
+            name: t.name,
+            P: 0,
+            W: 0,
+            D: 0,
+            L: 0,
+            GF: 0,
+            GA: 0,
+            GD: 0,
+            Pts: 0,
+          })),
+        );
+      } else {
+        setRows(sRows);
+      }
+    });
     return unsub;
   }, [leagueId]);
 

--- a/src/services/leagues.test.ts
+++ b/src/services/leagues.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listLeagues } from './leagues';
+
+vi.mock('./firebase', () => ({ db: {} }));
+
+const collectionMock = vi.fn();
+const getDocsMock = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...args: unknown[]) => collectionMock(...args),
+  getDocs: (...args: unknown[]) => getDocsMock(...args),
+}));
+
+describe('listLeagues', () => {
+  beforeEach(() => {
+    collectionMock.mockClear();
+    getDocsMock.mockReset();
+  });
+
+  it('returns empty array when no leagues exist', async () => {
+    getDocsMock.mockResolvedValueOnce({ docs: [] });
+    const leagues = await listLeagues();
+    expect(leagues).toEqual([]);
+  });
+
+  it('returns leagues with teams', async () => {
+    const leagueDoc = {
+      id: 'l1',
+      data: () => ({ name: 'League 1', capacity: 22, season: 1, state: 'forming' }),
+      ref: {},
+    };
+    const teamDocs = [
+      { id: 't1', data: () => ({ name: 'Team 1' }) },
+      { id: 't2', data: () => ({}) },
+    ];
+    getDocsMock
+      .mockResolvedValueOnce({ docs: [leagueDoc] })
+      .mockResolvedValueOnce({ docs: teamDocs, size: teamDocs.length });
+    const leagues = await listLeagues();
+    expect(leagues.length).toBe(1);
+    expect(leagues[0]).toMatchObject({
+      id: 'l1',
+      name: 'League 1',
+      capacity: 22,
+      season: 1,
+      state: 'forming',
+      teamCount: 2,
+    });
+    expect(leagues[0].teams).toEqual([
+      { id: 't1', name: 'Team 1' },
+      { id: 't2', name: 't2' },
+    ]);
+  });
+});

--- a/src/services/leagues.ts
+++ b/src/services/leagues.ts
@@ -47,7 +47,7 @@ export async function getFixturesForTeam(leagueId: string, teamId: string): Prom
   const q = query(col, where('participants', 'array-contains', teamId), orderBy('date'));
   const snap = await getDocs(q);
   return snap.docs.map((d) => {
-    const data = d.data() as any;
+    const data = d.data() as { date: { toDate: () => Date } } & Omit<Fixture, 'id' | 'date'>;
     return { id: d.id, ...data, date: data.date.toDate() } as Fixture;
   });
 }


### PR DESCRIPTION
## Summary
- Display league teams even before standings exist
- Add unit tests for league listing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af581702a8832a89039a20baf1b170