### PR TITLE
feat: add http fallback for league assignment

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,6 @@
 export {
   assignTeamToLeague,
+  assignTeamToLeagueHttp,
   assignAllTeamsToLeagues,
   generateRoundRobinFixturesFn,
 } from './league';


### PR DESCRIPTION
## Summary
- add HTTP Cloud Function assignTeamToLeagueHttp with auth
- expose HTTP function and update client to retry via HTTP when callable fails

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a23fe584832a97e5e615cca6c847