### PR TITLE
Add legend card pack system

### DIFF
--- a/src/contexts/DiamondContext.tsx
+++ b/src/contexts/DiamondContext.tsx
@@ -1,11 +1,17 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { ensureUserDoc, listenDiamondBalance, mockPurchaseDiamonds } from '@/services/diamonds';
+import {
+  ensureUserDoc,
+  listenDiamondBalance,
+  mockPurchaseDiamonds,
+  spendDiamonds,
+} from '@/services/diamonds';
 import type { DiamondPack } from '@/features/diamonds/packs';
 
 interface DiamondContextValue {
   balance: number;
   purchase: (pack: DiamondPack) => Promise<void>;
+  spend: (amount: number) => Promise<void>;
 }
 
 const DiamondContext = createContext<DiamondContextValue | undefined>(undefined);
@@ -30,8 +36,13 @@ export const DiamondProvider: React.FC<{ children: ReactNode }> = ({ children })
     });
   };
 
+  const spend = async (amount: number) => {
+    if (!user) return;
+    await spendDiamonds(user.id, amount);
+  };
+
   return (
-    <DiamondContext.Provider value={{ balance, purchase }}>
+    <DiamondContext.Provider value={{ balance, purchase, spend }}>
       {children}
     </DiamondContext.Provider>
   );

--- a/src/features/legends/LegendCard.tsx
+++ b/src/features/legends/LegendCard.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import type { LegendPlayer } from './players';
+import './legend-card.css';
+
+interface Props {
+  player: LegendPlayer;
+}
+
+export default function LegendCard({ player }: Props) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const id = setTimeout(() => setShow(true), 50);
+    return () => clearTimeout(id);
+  }, [player]);
+
+  return (
+    <div className="legend-card-wrapper">
+      <div className={`legend-card ${show ? 'show' : 'reveal'} ${player.rarity}`}>
+        <h3>{player.name}</h3>
+        <p>Güç: {player.rating}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/legends/LegendPackPage.tsx
+++ b/src/features/legends/LegendPackPage.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useDiamonds } from '@/contexts/DiamondContext';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import LegendCard from './LegendCard';
+import { LEGEND_PLAYERS, type LegendPlayer } from './players';
+import { drawLegend } from './drawLegend';
+
+const PACK_COST = 1;
+
+const LegendPackPage = () => {
+  const { user } = useAuth();
+  const { balance, spend } = useDiamonds();
+  const [current, setCurrent] = useState<LegendPlayer | null>(null);
+
+  const handleOpen = async () => {
+    if (!user) {
+      toast.error('Giriş yapmalısın');
+      return;
+    }
+    if (balance < PACK_COST) {
+      toast.error('Yeterli elmas yok');
+      return;
+    }
+    try {
+      await spend(PACK_COST);
+      const p = drawLegend(LEGEND_PLAYERS);
+      setCurrent(p);
+    } catch (err) {
+      console.warn(err);
+      toast.error('İşlem başarısız');
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Nostalji Paket</h1>
+      <div>Elmas: {balance}</div>
+      <Button onClick={handleOpen} disabled={balance < PACK_COST}>
+        Paket Aç (1💎)
+      </Button>
+      {current && <LegendCard player={current} />}
+    </div>
+  );
+};
+
+export default LegendPackPage;

--- a/src/features/legends/drawLegend.ts
+++ b/src/features/legends/drawLegend.ts
@@ -1,0 +1,13 @@
+import type { LegendPlayer } from './players';
+
+export function drawLegend(players: LegendPlayer[]): LegendPlayer {
+  const total = players.reduce((sum, p) => sum + p.weight, 0);
+  let target = Math.random() * total;
+  for (const p of players) {
+    target -= p.weight;
+    if (target <= 0) {
+      return p;
+    }
+  }
+  return players[players.length - 1];
+}

--- a/src/features/legends/legend-card.css
+++ b/src/features/legends/legend-card.css
@@ -1,0 +1,41 @@
+.legend-card-wrapper {
+  width: 300px;
+  height: 450px;
+  margin: 0 auto;
+  perspective: 1000px;
+}
+
+.legend-card {
+  width: 100%;
+  height: 100%;
+  background: #2f2f2f;
+  color: #fff;
+  border-radius: 10px;
+  transform-style: preserve-3d;
+  transition: transform 1s ease, box-shadow 1s ease;
+  text-align: center;
+  padding-top: 150px;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+}
+
+.legend-card.reveal {
+  transform: rotateY(180deg);
+  box-shadow: 0 0 50px rgba(255, 215, 0, 0.8);
+}
+
+.legend-card.show {
+  transform: rotateY(0deg);
+  box-shadow: 0 0 20px rgba(255, 255, 255, 0.5);
+}
+
+.legend-card.legend {
+  background: gold;
+}
+
+.legend-card.rare {
+  background: purple;
+}
+
+.legend-card.common {
+  background: silver;
+}

--- a/src/features/legends/players.ts
+++ b/src/features/legends/players.ts
@@ -1,0 +1,16 @@
+export type LegendPlayer = {
+  id: number;
+  name: string;
+  rating: number;
+  rarity: 'legend' | 'rare' | 'common';
+  weight: number;
+};
+
+export const LEGEND_PLAYERS: LegendPlayer[] = [
+  { id: 1, name: 'Pelé', rating: 98, rarity: 'legend', weight: 1 },
+  { id: 2, name: 'Maradona', rating: 97, rarity: 'legend', weight: 1 },
+  { id: 3, name: 'Zico', rating: 93, rarity: 'rare', weight: 5 },
+  { id: 4, name: 'Johan Cruyff', rating: 96, rarity: 'legend', weight: 1 },
+  { id: 5, name: 'Eric Cantona', rating: 90, rarity: 'rare', weight: 3 },
+  { id: 6, name: 'Bobby Charlton', rating: 91, rarity: 'rare', weight: 3 },
+];

--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -8,17 +8,18 @@ import {
   Users, 
   UserPlus, 
   Calendar, 
-  Trophy, 
-  Dumbbell, 
-  Play, 
-  History, 
-  DollarSign, 
-  User, 
-  Settings, 
-  Moon, 
+  Trophy,
+  Dumbbell,
+  Play,
+  History,
+  DollarSign,
+  User,
+  Settings,
+  Moon,
   Sun,
   LogOut,
-  Bell
+  Bell,
+  Star
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getMyLeagueId, listLeagueStandings, getFixturesForTeam } from '@/services/leagues';
@@ -35,6 +36,7 @@ const menuItems = [
   { id: 'finance', label: 'Finans', icon: DollarSign, color: 'bg-emerald-500' },
   { id: 'profile', label: 'Kişisel Bilgiler', icon: User, color: 'bg-indigo-500' },
   { id: 'settings', label: 'Ayarlar', icon: Settings, color: 'bg-slate-500' },
+  { id: 'legend-pack', label: 'Nostalji Paket', icon: Star, color: 'bg-pink-500' },
 ];
 
 export default function MainMenu() {

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -13,6 +13,7 @@ import Settings from '@/pages/Settings';
 import NotFound from '@/pages/NotFound';
 import DiamondsPage from '@/features/diamonds/DiamondsPage';
 import AcademyPage from '@/features/academy/AcademyPage';
+import LegendPackPage from '@/features/legends/LegendPackPage';
 import StandingsPage from '@/pages/StandingsPage';
 
 export default function AppRoutes() {
@@ -35,6 +36,7 @@ export default function AppRoutes() {
       <Route path="/settings" element={<Settings />} />
       <Route path="/store/diamonds" element={<DiamondsPage />} />
       <Route path="/academy" element={<AcademyPage />} />
+      <Route path="/legend-pack" element={<LegendPackPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/src/services/diamonds.ts
+++ b/src/services/diamonds.ts
@@ -57,3 +57,21 @@ export async function mockPurchaseDiamonds(
     throw err;
   }
 }
+
+export async function spendDiamonds(uid: string, amount: number): Promise<void> {
+  const userRef = doc(db, 'users', uid);
+  try {
+    await runTransaction(db, async (tx) => {
+      const snap = await tx.get(userRef);
+      const balance = (snap.data()?.diamondBalance ?? 0) as number;
+      if (balance < amount) {
+        throw new Error('Yeterli elmas yok');
+      }
+      tx.update(userRef, { diamondBalance: balance - amount });
+    });
+  } catch (err) {
+    console.warn(err);
+    toast.error('Yeterli elmas yok');
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce weighted draw function and nostalgic legend player list
- allow spending diamonds and add context support
- add Legend Pack page with animated card reveal and menu entry

## Testing
- `npm run lint` *(fails: Unexpected any ...)*
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd1ee5d10832a84b2cab4326dac47