### PR TITLE
feat: add legend card images and rental options

### DIFF
--- a/src/features/legends/LegendCard.tsx
+++ b/src/features/legends/LegendCard.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
 import type { LegendPlayer } from './players';
+import { Button } from '@/components/ui/button';
 import './legend-card.css';
 
 interface Props {
   player: LegendPlayer;
+  onRent?: (p: LegendPlayer) => void;
+  onRelease?: (p: LegendPlayer) => void;
 }
 
-export default function LegendCard({ player }: Props) {
+export default function LegendCard({ player, onRent, onRelease }: Props) {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
@@ -17,8 +20,27 @@ export default function LegendCard({ player }: Props) {
   return (
     <div className="legend-card-wrapper">
       <div className={`legend-card ${show ? 'show' : 'reveal'} ${player.rarity}`}>
-        <h3>{player.name}</h3>
+        <div className="flex flex-col items-center gap-2">
+          <img
+            src={player.image}
+            alt={player.name}
+            className="w-16 h-16 rounded-full object-cover"
+          />
+          <h3 className="flex items-center gap-2">{player.name}</h3>
+        </div>
         <p>Güç: {player.rating}</p>
+        <div className="mt-4 flex justify-center gap-2">
+          {onRent && (
+            <Button size="sm" onClick={() => onRent(player)}>
+              Oyuncuyu kirala
+            </Button>
+          )}
+          {onRelease && (
+            <Button size="sm" variant="secondary" onClick={() => onRelease(player)}>
+              Serbest bırak
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/features/legends/LegendPackPage.tsx
+++ b/src/features/legends/LegendPackPage.tsx
@@ -8,11 +8,17 @@ import { LEGEND_PLAYERS, type LegendPlayer } from './players';
 import { drawLegend } from './drawLegend';
 
 const PACK_COST = 1;
+const LEAGUE_DURATION_MS = 1000 * 60 * 60 * 24 * 90;
+
+interface RentedLegend extends LegendPlayer {
+  expiresAt: Date;
+}
 
 const LegendPackPage = () => {
   const { user } = useAuth();
   const { balance, spend } = useDiamonds();
   const [current, setCurrent] = useState<LegendPlayer | null>(null);
+  const [rented, setRented] = useState<RentedLegend[]>([]);
 
   const handleOpen = async () => {
     if (!user) {
@@ -33,6 +39,18 @@ const LegendPackPage = () => {
     }
   };
 
+  const handleRent = (player: LegendPlayer) => {
+    const expiresAt = new Date(Date.now() + LEAGUE_DURATION_MS);
+    setRented((prev) => [...prev, { ...player, expiresAt }]);
+    toast.success(`${player.name} kiralandı`);
+    setCurrent(null);
+  };
+
+  const handleRelease = () => {
+    toast.message('Kart serbest bırakıldı');
+    setCurrent(null);
+  };
+
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Nostalji Paket</h1>
@@ -40,7 +58,26 @@ const LegendPackPage = () => {
       <Button onClick={handleOpen} disabled={balance < PACK_COST}>
         Paket Aç (1💎)
       </Button>
-      {current && <LegendCard player={current} />}
+      {current && (
+        <LegendCard
+          player={current}
+          onRent={handleRent}
+          onRelease={handleRelease}
+        />
+      )}
+      {rented.length > 0 && (
+        <div className="pt-4">
+          <h2 className="text-xl font-semibold">Kiralanan Oyuncular</h2>
+          <ul className="list-disc list-inside">
+            {rented.map((p) => (
+              <li key={p.id}>
+                {p.name} - Sözleşme bitiş:{' '}
+                {p.expiresAt.toLocaleDateString()}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/legends/players.ts
+++ b/src/features/legends/players.ts
@@ -4,13 +4,62 @@ export type LegendPlayer = {
   rating: number;
   rarity: 'legend' | 'rare' | 'common';
   weight: number;
+  image: string;
 };
 
 export const LEGEND_PLAYERS: LegendPlayer[] = [
-  { id: 1, name: 'Pelé', rating: 98, rarity: 'legend', weight: 1 },
-  { id: 2, name: 'Maradona', rating: 97, rarity: 'legend', weight: 1 },
-  { id: 3, name: 'Zico', rating: 93, rarity: 'rare', weight: 5 },
-  { id: 4, name: 'Johan Cruyff', rating: 96, rarity: 'legend', weight: 1 },
-  { id: 5, name: 'Eric Cantona', rating: 90, rarity: 'rare', weight: 3 },
-  { id: 6, name: 'Bobby Charlton', rating: 91, rarity: 'rare', weight: 3 },
+  {
+    id: 1,
+    name: 'Pelé',
+    rating: 98,
+    rarity: 'legend',
+    weight: 1,
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Pele_1970.jpg/64px-Pele_1970.jpg',
+  },
+  {
+    id: 2,
+    name: 'Maradona',
+    rating: 97,
+    rarity: 'legend',
+    weight: 1,
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Diego_Maradona_2017.jpg/64px-Diego_Maradona_2017.jpg',
+  },
+  {
+    id: 3,
+    name: 'Zico',
+    rating: 93,
+    rarity: 'rare',
+    weight: 5,
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Zico_1981.jpg/64px-Zico_1981.jpg',
+  },
+  {
+    id: 4,
+    name: 'Johan Cruyff',
+    rating: 96,
+    rarity: 'legend',
+    weight: 1,
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Johan_Cruyff_1974.jpg/64px-Johan_Cruyff_1974.jpg',
+  },
+  {
+    id: 5,
+    name: 'Eric Cantona',
+    rating: 90,
+    rarity: 'rare',
+    weight: 3,
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Eric_Cantona_2011.jpg/64px-Eric_Cantona_2011.jpg',
+  },
+  {
+    id: 6,
+    name: 'Bobby Charlton',
+    rating: 91,
+    rarity: 'rare',
+    weight: 3,
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Bobby_Charlton_in_1969.jpg/64px-Bobby_Charlton_in_1969.jpg',
+  },
 ];


### PR DESCRIPTION
## Summary
- display player images on legend cards
- allow renting drawn legends for a league season and releasing cards
- show rented players with contract expiration date

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd78a0cfc832a8fab6b5f1a3418f2