### PR TITLE
feat: save rented legends to team and firebase

### DIFF
--- a/src/features/legends/LegendPackPage.tsx
+++ b/src/features/legends/LegendPackPage.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import LegendCard from './LegendCard';
 import { LEGEND_PLAYERS, type LegendPlayer } from './players';
 import { drawLegend } from './drawLegend';
+import { rentLegend } from '@/services/legends';
 
 const PACK_COST = 1;
 const LEAGUE_DURATION_MS = 1000 * 60 * 60 * 24 * 90;
@@ -39,10 +40,17 @@ const LegendPackPage = () => {
     }
   };
 
-  const handleRent = (player: LegendPlayer) => {
+  const handleRent = async (player: LegendPlayer) => {
+    if (!user) return;
     const expiresAt = new Date(Date.now() + LEAGUE_DURATION_MS);
-    setRented((prev) => [...prev, { ...player, expiresAt }]);
-    toast.success(`${player.name} kiralandı`);
+    try {
+      await rentLegend(user.id, player, expiresAt);
+      setRented((prev) => [...prev, { ...player, expiresAt }]);
+      toast.success(`${player.name} kiralandı`);
+    } catch (err) {
+      console.warn(err);
+      toast.error('İşlem başarısız');
+    }
     setCurrent(null);
   };
 

--- a/src/features/legends/players.ts
+++ b/src/features/legends/players.ts
@@ -1,3 +1,5 @@
+import type { Player } from '@/types';
+
 export type LegendPlayer = {
   id: number;
   name: string;
@@ -5,6 +7,7 @@ export type LegendPlayer = {
   rarity: 'legend' | 'rare' | 'common';
   weight: number;
   image: string;
+  position: Player['position'];
 };
 
 export const LEGEND_PLAYERS: LegendPlayer[] = [
@@ -16,6 +19,7 @@ export const LEGEND_PLAYERS: LegendPlayer[] = [
     weight: 1,
     image:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Pele_1970.jpg/64px-Pele_1970.jpg',
+    position: 'ST',
   },
   {
     id: 2,
@@ -25,6 +29,7 @@ export const LEGEND_PLAYERS: LegendPlayer[] = [
     weight: 1,
     image:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Diego_Maradona_2017.jpg/64px-Diego_Maradona_2017.jpg',
+    position: 'CAM',
   },
   {
     id: 3,
@@ -34,6 +39,7 @@ export const LEGEND_PLAYERS: LegendPlayer[] = [
     weight: 5,
     image:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Zico_1981.jpg/64px-Zico_1981.jpg',
+    position: 'CAM',
   },
   {
     id: 4,
@@ -43,6 +49,7 @@ export const LEGEND_PLAYERS: LegendPlayer[] = [
     weight: 1,
     image:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Johan_Cruyff_1974.jpg/64px-Johan_Cruyff_1974.jpg',
+    position: 'LW',
   },
   {
     id: 5,
@@ -52,6 +59,7 @@ export const LEGEND_PLAYERS: LegendPlayer[] = [
     weight: 3,
     image:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Eric_Cantona_2011.jpg/64px-Eric_Cantona_2011.jpg',
+    position: 'ST',
   },
   {
     id: 6,
@@ -61,5 +69,6 @@ export const LEGEND_PLAYERS: LegendPlayer[] = [
     weight: 3,
     image:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Bobby_Charlton_in_1969.jpg/64px-Bobby_Charlton_in_1969.jpg',
+    position: 'CM',
   },
 ];

--- a/src/services/legends.ts
+++ b/src/services/legends.ts
@@ -1,0 +1,56 @@
+import { doc, setDoc, Timestamp } from 'firebase/firestore';
+import { db } from './firebase';
+import { addPlayerToTeam } from './team';
+import type { LegendPlayer } from '@/features/legends/players';
+import type { Player } from '@/types';
+import { getRoles } from '@/lib/player';
+
+function legendToPlayer(id: string, legend: LegendPlayer): Player {
+  const rating = legend.rating / 100;
+  const attributes: Player['attributes'] = {
+    strength: rating,
+    acceleration: rating,
+    topSpeed: rating,
+    dribbleSpeed: rating,
+    jump: rating,
+    tackling: rating,
+    ballKeeping: rating,
+    passing: rating,
+    longBall: rating,
+    agility: rating,
+    shooting: rating,
+    shootPower: rating,
+    positioning: rating,
+    reaction: rating,
+    ballControl: rating,
+  };
+  return {
+    id,
+    name: legend.name,
+    position: legend.position,
+    roles: getRoles(legend.position),
+    overall: rating,
+    potential: rating,
+    attributes,
+    age: 35,
+    height: 180,
+    weight: 75,
+    squadRole: 'reserve',
+  };
+}
+
+export async function rentLegend(
+  uid: string,
+  legend: LegendPlayer,
+  expiresAt: Date,
+): Promise<Player> {
+  const playerId = `legend-${legend.id}-${Date.now()}`;
+  const player = legendToPlayer(playerId, legend);
+  await addPlayerToTeam(uid, player);
+  await setDoc(
+    doc(db, 'users', uid, 'rentedLegends', playerId),
+    { legendId: legend.id, expiresAt: Timestamp.fromDate(expiresAt) },
+  );
+  return player;
+}
+


### PR DESCRIPTION
## Summary
- add positions to legend player data
- convert rented legends to team players and persist in Firestore
- update legend pack page to save rented players

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdd941a548832a96697ba7c21c5e0f