### PR TITLE
Add back navigation to youth, leagues and legend pack pages

### DIFF
--- a/src/features/academy/AcademyPage.tsx
+++ b/src/features/academy/AcademyPage.tsx
@@ -16,6 +16,7 @@ import CooldownPanel from './CooldownPanel';
 import CandidatesList from './CandidatesList';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { BackButton } from '@/components/ui/back-button';
 
 const STORAGE_KEY = 'academyCandidates';
 const NEXT_PULL_KEY = 'academyNextPullAt';
@@ -152,7 +153,10 @@ const AcademyPage = () => {
   return (
     <div className="p-4 space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Altyapı</h1>
+        <div className="flex items-center gap-2">
+          <BackButton />
+          <h1 className="text-2xl font-bold">Altyapı</h1>
+        </div>
         <Button onClick={handlePull} disabled={!canPull} data-testid="academy-pull">
           Oyuncu Üret
         </Button>

--- a/src/features/legends/LegendPackPage.tsx
+++ b/src/features/legends/LegendPackPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDiamonds } from '@/contexts/DiamondContext';
 import { Button } from '@/components/ui/button';
+import { BackButton } from '@/components/ui/back-button';
 import { toast } from 'sonner';
 import LegendCard from './LegendCard';
 import { LEGEND_PLAYERS, type LegendPlayer } from './players';
@@ -61,7 +62,10 @@ const LegendPackPage = () => {
 
   return (
     <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Nostalji Paket</h1>
+      <div className="flex items-center gap-2">
+        <BackButton />
+        <h1 className="text-2xl font-bold">Nostalji Paket</h1>
+      </div>
       <div>Elmas: {balance}</div>
       <Button onClick={handleOpen} disabled={balance < PACK_COST}>
         Paket Aç (1💎)

--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -20,6 +20,7 @@ import { Button } from '@/components/ui/button';
 import YouthList from './YouthList';
 import CooldownPanel from './CooldownPanel';
 import type { Player } from '@/types';
+import { BackButton } from '@/components/ui/back-button';
 
 const positions: Player['position'][] = ['GK','CB','LB','RB','CM','LM','RM','CAM','LW','RW','ST'];
 const randomAttr = () => parseFloat(Math.random().toFixed(3));
@@ -153,7 +154,10 @@ const YouthPage = () => {
   return (
     <div className="p-4 space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Altyapı</h1>
+        <div className="flex items-center gap-2">
+          <BackButton />
+          <h1 className="text-2xl font-bold">Altyapı</h1>
+        </div>
         <Button onClick={handleGenerate} disabled={!canGenerate} data-testid="youth-generate">
           Oyuncu Üret
         </Button>

--- a/src/pages/LeaguesListPage.tsx
+++ b/src/pages/LeaguesListPage.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { useAuth } from '@/contexts/AuthContext';
 import { ensureDefaultLeague, listLeagues, listenMyLeague } from '@/services/leagues';
 import type { League } from '@/types';
+import { BackButton } from '@/components/ui/back-button';
 
 export default function LeaguesListPage() {
   const navigate = useNavigate();
@@ -34,7 +35,10 @@ export default function LeaguesListPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Ligler</h1>
+      <div className="flex items-center gap-2 mb-4">
+        <BackButton />
+        <h1 className="text-xl font-bold">Ligler</h1>
+      </div>
       {leagues.length === 0 && (
         <p
           data-testid="no-leagues-message"


### PR DESCRIPTION
## Summary
- add BackButton to Nostalji Paket page for easy return
- include BackButton on leagues list screen
- wire BackButton into academy and youth pages

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68bde170ae94832aa51a117d742452cb