### PR TITLE
Inline diamond icon with pack amount

### DIFF
--- a/src/features/diamonds/PacksGrid.tsx
+++ b/src/features/diamonds/PacksGrid.tsx
@@ -23,8 +23,10 @@ const PacksGrid: React.FC<Props> = ({ packs, onSelect }) => (
           </CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col items-center gap-2">
-          <Diamond className="h-6 w-6 text-blue-500" />
-          <span className="text-lg font-bold">{pack.amount}</span>
+          <span className="flex items-center gap-1 text-lg font-bold">
+            <Diamond className="h-6 w-6 text-blue-500" />
+            {pack.amount}
+          </span>
           {pack.priceFiat && (
             <span className="text-sm text-muted-foreground">₺{pack.priceFiat.toFixed(2)}</span>
           )}


### PR DESCRIPTION
## Summary
- inline diamond icon with pack amount in PackGrid cards for better layout

## Testing
- `pnpm lint` *(fails: Unexpected any, empty block statement)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde2c2b2fc832a9047dfce08fd5a1d