### PR TITLE
feat(auth): add google and apple login

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,7 +8,13 @@ import React, {
 import { onAuthStateChanged, updateProfile } from 'firebase/auth';
 import { User } from '@/types';
 import { auth } from '@/services/firebase';
-import { signIn, signUp, signOutUser } from '@/services/auth';
+import {
+  signIn,
+  signUp,
+  signOutUser,
+  signInWithGoogle,
+  signInWithApple,
+} from '@/services/auth';
 import { createInitialTeam, getTeam } from '@/services/team';
 import { requestJoinLeague } from '@/services/leagues';
 import { generateRandomName } from '@/lib/names';
@@ -18,6 +24,8 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string, teamName: string) => Promise<void>;
   logout: () => Promise<void>;
+  loginWithGoogle: () => Promise<void>;
+  loginWithApple: () => Promise<void>;
   isLoading: boolean;
 }
 
@@ -114,8 +122,36 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setUser(null);
   };
 
+  const loginWithGoogle = async () => {
+    setIsLoading(true);
+    try {
+      await signInWithGoogle();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const loginWithApple = async () => {
+    setIsLoading(true);
+    try {
+      await signInWithApple();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
-    <AuthContext.Provider value={{ user, login, register, logout, isLoading }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        login,
+        register,
+        logout,
+        loginWithGoogle,
+        loginWithApple,
+        isLoading,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -10,7 +10,7 @@ import { toast } from 'sonner';
 import { Loader2, Chrome, Apple } from 'lucide-react';
 
 export default function Auth() {
-  const { login, register, isLoading } = useAuth();
+  const { login, register, loginWithGoogle, loginWithApple, isLoading } = useAuth();
   const [loginForm, setLoginForm] = useState({ email: '', password: '' });
   const [registerForm, setRegisterForm] = useState({ email: '', password: '', teamName: '' });
 
@@ -42,6 +42,26 @@ export default function Auth() {
       toast.success('Hesap başarıyla oluşturuldu!');
     } catch (error) {
       toast.error('Kayıt başarısız');
+    }
+  };
+
+  const handleGoogleAuth = async () => {
+    try {
+      await loginWithGoogle();
+      toast.success('Başarıyla giriş yapıldı!');
+    } catch (error) {
+      toast.error('Google ile giriş başarısız');
+      console.error('google login error:', error);
+    }
+  };
+
+  const handleAppleAuth = async () => {
+    try {
+      await loginWithApple();
+      toast.success('Başarıyla giriş yapıldı!');
+    } catch (error) {
+      toast.error('Apple ile giriş başarısız');
+      console.error('apple login error:', error);
     }
   };
 
@@ -104,11 +124,21 @@ export default function Auth() {
               </div>
 
               <div className="space-y-2">
-                <Button variant="outline" className="w-full" disabled={isLoading}>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={handleGoogleAuth}
+                  disabled={isLoading}
+                >
                   <Chrome className="w-4 h-4 mr-2" />
                   Google ile Giriş
                 </Button>
-                <Button variant="outline" className="w-full" disabled={isLoading}>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={handleAppleAuth}
+                  disabled={isLoading}
+                >
                   <Apple className="w-4 h-4 mr-2" />
                   Apple ile Giriş
                 </Button>
@@ -165,11 +195,21 @@ export default function Auth() {
               </div>
 
               <div className="space-y-2">
-                <Button variant="outline" className="w-full" disabled={isLoading}>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={handleGoogleAuth}
+                  disabled={isLoading}
+                >
                   <Chrome className="w-4 h-4 mr-2" />
                   Google ile Kayıt
                 </Button>
-                <Button variant="outline" className="w-full" disabled={isLoading}>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={handleAppleAuth}
+                  disabled={isLoading}
+                >
                   <Apple className="w-4 h-4 mr-2" />
                   Apple ile Kayıt
                 </Button>

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -2,6 +2,9 @@ import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
   signOut,
+  signInWithPopup,
+  GoogleAuthProvider,
+  OAuthProvider,
 } from "firebase/auth";
 import { auth } from "./firebase";
 
@@ -12,3 +15,11 @@ export const signIn = (email: string, password: string) =>
   signInWithEmailAndPassword(auth, email, password);
 
 export const signOutUser = () => signOut(auth);
+
+const googleProvider = new GoogleAuthProvider();
+export const signInWithGoogle = () => signInWithPopup(auth, googleProvider);
+
+const appleProvider = new OAuthProvider('apple.com');
+appleProvider.addScope('email');
+appleProvider.addScope('name');
+export const signInWithApple = () => signInWithPopup(auth, appleProvider);


### PR DESCRIPTION
## Summary
- enable Firebase Google and Apple provider sign-in
- expose provider login functions in auth context
- wire login/register UI buttons to trigger provider auth

## Testing
- `pnpm lint` *(fails: Unexpected any in existing files)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bde47a7af0832ab1d48dedc4fe86fb