### PR TITLE
Adjust youth recruitment cadence and add ad accelerators

### DIFF
--- a/src/features/youth/CooldownPanel.tsx
+++ b/src/features/youth/CooldownPanel.tsx
@@ -2,15 +2,27 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { YOUTH_COOLDOWN_MS } from '@/services/youth';
+import {
+  YOUTH_AD_REDUCTION_MS,
+  YOUTH_COOLDOWN_MS,
+  YOUTH_RESET_DIAMOND_COST,
+} from '@/services/youth';
 
 interface Props {
   nextGenerateAt: Date | null;
   onReset: () => void;
   canReset: boolean;
+  onWatchAd: () => void;
+  canWatchAd: boolean;
 }
 
-const CooldownPanel: React.FC<Props> = ({ nextGenerateAt, onReset, canReset }) => {
+const CooldownPanel: React.FC<Props> = ({
+  nextGenerateAt,
+  onReset,
+  canReset,
+  onWatchAd,
+  canWatchAd,
+}) => {
   const [remaining, setRemaining] = useState(0);
 
   useEffect(() => {
@@ -48,19 +60,37 @@ const CooldownPanel: React.FC<Props> = ({ nextGenerateAt, onReset, canReset }) =
       </CardHeader>
       <CardContent className="space-y-2">
         <Progress value={progress} className="h-2" />
-        <div className="flex items-center justify-between text-sm">
-          <span>
-            Sonraki üretim: {hours}:{minutes}:{seconds}
-          </span>
-          <Button
-            onClick={onReset}
-            disabled={!canReset || canGenerate}
-            size="sm"
-            variant="secondary"
-            data-testid="youth-reset"
-          >
-            Hızlandır (💎5)
-          </Button>
+        <div className="space-y-3 text-sm">
+          <div className="flex items-center justify-between">
+            <span>
+              Sonraki üretim: {hours}:{minutes}:{seconds}
+            </span>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <Button
+                onClick={onWatchAd}
+                disabled={!canWatchAd}
+                size="sm"
+                variant="outline"
+                data-testid="youth-watch-ad"
+              >
+                Reklam İzle (-12 saat)
+              </Button>
+              <Button
+                onClick={onReset}
+                disabled={!canReset || canGenerate}
+                size="sm"
+                variant="secondary"
+                data-testid="youth-reset"
+              >
+                Hemen Al (💎{YOUTH_RESET_DIAMOND_COST})
+              </Button>
+            </div>
+          </div>
+          <p className="text-muted-foreground">
+            Altyapı oyuncuları haftada bir gelir. Reklam izleyerek bekleme süresini{' '}
+            {(YOUTH_AD_REDUCTION_MS / 3600000).toFixed(0)} saat kısaltabilir veya elmas
+            kullanarak hemen yeni oyuncu alabilirsin.
+          </p>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- change youth candidate cooldown to a weekly cadence and expose the cost and timing constants
- add an advertisement shortcut option alongside the diamond reset control in the youth cooldown panel
- surface the new controls in the youth page and cover the service logic with updated tests

## Testing
- `pnpm test -- src/services/youth.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68daf2d07830832a868ce1c6c05bd4f4