### PR TITLE
Add transfer market marketplace page

### DIFF
--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -19,6 +19,7 @@ import {
   Sun,
   LogOut,
   Bell,
+  ShoppingCart,
   Star
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -28,6 +29,7 @@ import { getTeam } from '@/services/team';
 const menuItems = [
   { id: 'team-planning', label: 'Takım Planı', icon: Users, color: 'bg-blue-500' },
   { id: 'youth', label: 'Altyapı', icon: UserPlus, color: 'bg-green-500' },
+  { id: 'transfer-market', label: 'Transfer Pazarı', icon: ShoppingCart, color: 'bg-teal-500' },
   { id: 'fixtures', label: 'Fikstür', icon: Calendar, color: 'bg-purple-500' },
   { id: 'leagues', label: 'Ligler', icon: Trophy, color: 'bg-yellow-500' },
   { id: 'training', label: 'Antrenman', icon: Dumbbell, color: 'bg-orange-500' },

--- a/src/pages/TransferMarket.tsx
+++ b/src/pages/TransferMarket.tsx
@@ -1,0 +1,500 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { BackButton } from '@/components/ui/back-button';
+import { Loader2, PlusCircle, ShoppingCart, Shield } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { Player, TransferListing } from '@/types';
+import { getTeam } from '@/services/team';
+import {
+  createTransferListing,
+  listenAvailableTransferListings,
+  purchaseTransferListing,
+} from '@/services/transferMarket';
+
+const POSITIONS: Player['position'][] = [
+  'GK',
+  'CB',
+  'LB',
+  'RB',
+  'CM',
+  'LM',
+  'RM',
+  'CAM',
+  'LW',
+  'RW',
+  'ST',
+];
+
+type SortOption = 'overall-desc' | 'overall-asc' | 'price-asc' | 'price-desc';
+
+type FilterState = {
+  position: 'all' | Player['position'];
+  maxPrice: string;
+  sortBy: SortOption;
+};
+
+const formatPrice = (value: number) =>
+  `${value.toLocaleString('tr-TR')} ₺`;
+
+const formatOverall = (value: number) => value.toFixed(3);
+
+export default function TransferMarket() {
+  const { user } = useAuth();
+  const [teamPlayers, setTeamPlayers] = useState<Player[]>([]);
+  const [teamName, setTeamName] = useState<string>('');
+  const [isLoadingTeam, setIsLoadingTeam] = useState(false);
+  const [listings, setListings] = useState<TransferListing[]>([]);
+  const [selectedPlayerId, setSelectedPlayerId] = useState<string>('');
+  const [price, setPrice] = useState<string>('');
+  const [isListing, setIsListing] = useState(false);
+  const [purchasingId, setPurchasingId] = useState<string>('');
+  const [filters, setFilters] = useState<FilterState>({
+    position: 'all',
+    maxPrice: '',
+    sortBy: 'overall-desc',
+  });
+  const previousListingCount = useRef<number>(0);
+
+  const loadTeam = useCallback(async () => {
+    if (!user) return;
+    setIsLoadingTeam(true);
+    try {
+      const team = await getTeam(user.id);
+      setTeamPlayers(team?.players ?? []);
+      setTeamName(team?.name ?? user.teamName ?? 'Takımım');
+    } catch (error) {
+      console.error('[TransferMarket] takımı yükleme hatası', error);
+      toast.error('Takım bilgileri alınamadı.', {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsLoadingTeam(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    loadTeam();
+  }, [loadTeam]);
+
+  useEffect(() => {
+    const unsubscribe = listenAvailableTransferListings(setListings);
+    return unsubscribe;
+  }, []);
+
+  const myListings = useMemo(
+    () => (user ? listings.filter(listing => listing.sellerId === user.id) : []),
+    [listings, user],
+  );
+
+  useEffect(() => {
+    if (!user) return;
+    if (previousListingCount.current > myListings.length) {
+      loadTeam();
+    }
+    previousListingCount.current = myListings.length;
+  }, [loadTeam, myListings.length, user]);
+
+  const availablePlayers = useMemo(() => {
+    const listedIds = new Set(myListings.map(listing => listing.playerId));
+    return teamPlayers.filter(player => !listedIds.has(player.id));
+  }, [myListings, teamPlayers]);
+
+  const filteredListings = useMemo(() => {
+    return listings.filter(listing => {
+      const { position, maxPrice } = filters;
+      if (position !== 'all' && listing.player.position !== position) {
+        return false;
+      }
+      if (maxPrice) {
+        const max = Number(maxPrice);
+        if (!Number.isNaN(max) && listing.price > max) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [filters, listings]);
+
+  const sortedListings = useMemo(() => {
+    const sorted = [...filteredListings];
+    switch (filters.sortBy) {
+      case 'overall-asc':
+        sorted.sort((a, b) => a.player.overall - b.player.overall);
+        break;
+      case 'price-asc':
+        sorted.sort((a, b) => a.price - b.price);
+        break;
+      case 'price-desc':
+        sorted.sort((a, b) => b.price - a.price);
+        break;
+      case 'overall-desc':
+      default:
+        sorted.sort((a, b) => b.player.overall - a.player.overall);
+        break;
+    }
+    return sorted;
+  }, [filteredListings, filters.sortBy]);
+
+  const handleCreateListing = async () => {
+    if (!user) {
+      toast.error('Giriş yapmalısın.');
+      return;
+    }
+    const player = availablePlayers.find(p => p.id === selectedPlayerId);
+    if (!player) {
+      toast.error('Pazara koymak için bir oyuncu seç.');
+      return;
+    }
+    const priceValue = Number(price);
+    if (!Number.isFinite(priceValue) || priceValue <= 0) {
+      toast.error('Geçerli bir fiyat gir.');
+      return;
+    }
+
+    setIsListing(true);
+    try {
+      await createTransferListing({
+        sellerId: user.id,
+        sellerTeamName: teamName || user.teamName || 'Takımım',
+        player,
+        price: priceValue,
+      });
+      toast.success(`${player.name} transfer pazarına eklendi.`);
+      setSelectedPlayerId('');
+      setPrice('');
+      await loadTeam();
+    } catch (error) {
+      toast.error('İlan oluşturulamadı.', {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsListing(false);
+    }
+  };
+
+  const handlePurchase = async (listing: TransferListing) => {
+    if (!user) {
+      toast.error('Giriş yapmalısın.');
+      return;
+    }
+    if (listing.sellerId === user.id) {
+      toast.error('Kendi oyuncunu satın alamazsın.');
+      return;
+    }
+
+    setPurchasingId(listing.id);
+    try {
+      await purchaseTransferListing({
+        listingId: listing.id,
+        buyerId: user.id,
+        buyerTeamName: teamName || user.teamName || 'Takımım',
+      });
+      toast.success(`${listing.player.name} takımıza katıldı!`);
+      await loadTeam();
+    } catch (error) {
+      toast.error('Satın alma başarısız.', {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setPurchasingId('');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-slate-50 to-blue-50 dark:from-emerald-950 dark:via-slate-950 dark:to-blue-950">
+      <div className="max-w-6xl mx-auto px-4 py-8 space-y-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <BackButton />
+            <h1 className="text-3xl font-bold">Transfer Pazarı</h1>
+            <p className="text-muted-foreground max-w-2xl">
+              Oyuncularını pazara çıkar, eksik bölgeler için yeni yıldızlar keşfet.
+              Mevkilere, ortalama güce ve fiyata göre filtreleyerek hedeflediğin transferi kolayca bul.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 rounded-lg border bg-white/60 p-4 dark:bg-slate-900/60">
+            <Shield className="h-10 w-10 text-emerald-600" />
+            <div>
+              <p className="text-sm text-muted-foreground">Takım Adı</p>
+              <p className="font-semibold">{teamName || user?.teamName || 'Takımım'}</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
+          <Card>
+            <CardHeader className="flex flex-col gap-2 border-b bg-white/70 dark:bg-slate-900/60">
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <ShoppingCart className="h-5 w-5" />
+                Pazardaki Oyuncular
+              </CardTitle>
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div>
+                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
+                    Mevki
+                  </label>
+                  <Select
+                    value={filters.position}
+                    onValueChange={value =>
+                      setFilters(prev => ({ ...prev, position: value as FilterState['position'] }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Mevki seç" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Tümü</SelectItem>
+                      {POSITIONS.map(position => (
+                        <SelectItem key={position} value={position}>
+                          {position}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
+                    Maksimum Fiyat
+                  </label>
+                  <Input
+                    inputMode="numeric"
+                    type="number"
+                    min={0}
+                    placeholder="Örn. 500000"
+                    value={filters.maxPrice}
+                    onChange={event =>
+                      setFilters(prev => ({ ...prev, maxPrice: event.target.value }))
+                    }
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
+                    Sıralama
+                  </label>
+                  <Select
+                    value={filters.sortBy}
+                    onValueChange={value =>
+                      setFilters(prev => ({ ...prev, sortBy: value as SortOption }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Sırala" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="overall-desc">Güç (Yüksek &rarr; Düşük)</SelectItem>
+                      <SelectItem value="overall-asc">Güç (Düşük &rarr; Yüksek)</SelectItem>
+                      <SelectItem value="price-asc">Fiyat (Düşük &rarr; Yüksek)</SelectItem>
+                      <SelectItem value="price-desc">Fiyat (Yüksek &rarr; Düşük)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="p-0">
+              <div className="overflow-hidden">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Oyuncu</TableHead>
+                      <TableHead>Mevki</TableHead>
+                      <TableHead>Güç Ortalaması</TableHead>
+                      <TableHead>Satıcı</TableHead>
+                      <TableHead>Fiyat</TableHead>
+                      <TableHead className="text-right">İşlem</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {sortedListings.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={6} className="py-12 text-center text-muted-foreground">
+                          Filtrenize uyan aktif ilan bulunamadı.
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      sortedListings.map(listing => (
+                        <TableRow key={listing.id}>
+                          <TableCell>
+                            <div className="font-semibold">{listing.player.name}</div>
+                            <div className="text-xs text-muted-foreground">
+                              Yaş {listing.player.age} · Potansiyel {formatOverall(listing.player.potential)}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline">{listing.player.position}</Badge>
+                          </TableCell>
+                          <TableCell>{formatOverall(listing.player.overall)}</TableCell>
+                          <TableCell>{listing.sellerTeamName}</TableCell>
+                          <TableCell className="font-medium text-emerald-600">
+                            {formatPrice(listing.price)}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button
+                              size="sm"
+                              onClick={() => handlePurchase(listing)}
+                              disabled={
+                                listing.sellerId === user?.id || purchasingId === listing.id
+                              }
+                            >
+                              {purchasingId === listing.id ? (
+                                <>
+                                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                  İşlem Yapılıyor
+                                </>
+                              ) : (
+                                'Satın Al'
+                              )}
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <PlusCircle className="h-5 w-5" />
+                  Oyuncu İlanı Oluştur
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
+                    Oyuncu Seç
+                  </label>
+                  <Select
+                    value={selectedPlayerId}
+                    onValueChange={value => setSelectedPlayerId(value)}
+                    disabled={availablePlayers.length === 0 || isListing || isLoadingTeam}
+                  >
+                    <SelectTrigger>
+                      <SelectValue
+                        placeholder={
+                          isLoadingTeam
+                            ? 'Takım yükleniyor...'
+                            : availablePlayers.length === 0
+                              ? 'Pazara koyabileceğin oyuncu kalmadı'
+                              : 'Oyuncu seç'
+                        }
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availablePlayers.map(player => (
+                        <SelectItem key={player.id} value={player.id}>
+                          {player.name} · {player.position} · Overall {formatOverall(player.overall)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
+                    Satış Fiyatı (₺)
+                  </label>
+                  <Input
+                    type="number"
+                    inputMode="numeric"
+                    min={1}
+                    step="10000"
+                    placeholder="Örn. 250000"
+                    value={price}
+                    onChange={event => setPrice(event.target.value)}
+                    disabled={isListing}
+                  />
+                </div>
+                <Button
+                  className="w-full"
+                  onClick={handleCreateListing}
+                  disabled={!selectedPlayerId || !price || isListing}
+                >
+                  {isListing ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      İlan Oluşturuluyor
+                    </>
+                  ) : (
+                    'Pazara Ekle'
+                  )}
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                  İlan verdiğin oyuncular satılana kadar kadronda görünmeye devam eder. Satış gerçekleştiğinde oyuncu yeni
+                  takımına otomatik olarak transfer edilir.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Aktif İlanların</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {isLoadingTeam ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Kadron yükleniyor...
+                  </div>
+                ) : myListings.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    Şu anda pazarda aktif ilanların bulunmuyor.
+                  </p>
+                ) : (
+                  <ul className="space-y-3">
+                    {myListings.map(listing => (
+                      <li
+                        key={listing.id}
+                        className="flex items-center justify-between rounded-lg border bg-white/70 px-3 py-2 text-sm dark:bg-slate-900/60"
+                      >
+                        <div className="flex flex-col">
+                          <span className="font-medium">{listing.player.name}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {listing.player.position} · Overall {formatOverall(listing.player.overall)}
+                          </span>
+                        </div>
+                        <span className="font-semibold text-emerald-600">{formatPrice(listing.price)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,6 +1,7 @@
 ﻿import { Routes, Route } from 'react-router-dom';
 import MainMenu from '@/pages/MainMenu';
 import TeamPlanning from '@/pages/TeamPlanning';
+import TransferMarket from '@/pages/TransferMarket';
 import Youth from '@/pages/Youth';
 import MyFixturesPage from '@/pages/MyFixturesPage';
 import LeaguesListPage from '@/pages/LeaguesListPage';
@@ -24,6 +25,7 @@ export default function AppRoutes() {
       <Route path="/" element={<MainMenu />} />
       <Route path="/team-planning" element={<TeamPlanning />} />
       <Route path="/youth" element={<Youth />} />
+      <Route path="/transfer-market" element={<TransferMarket />} />
       <Route path="/fixtures" element={<MyFixturesPage />} />
       <Route path="/my-matches" element={<MyFixturesPage />} />
       <Route path="/standings" element={<StandingsPage />} />

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -4,6 +4,7 @@ import RootLayout from '@/layouts/RootLayout';
 // Pages
 import MainMenu from '@/pages/MainMenu';
 import TeamPlanning from '@/pages/TeamPlanning';
+import TransferMarket from '@/pages/TransferMarket';
 import Youth from '@/pages/Youth';
 import MyFixturesPage from '@/pages/MyFixturesPage';
 import LeaguesListPage from '@/pages/LeaguesListPage';
@@ -32,6 +33,7 @@ export const router = createBrowserRouter(
         { path: '/', element: <MainMenu /> },
         { path: '/team-planning', element: <TeamPlanning /> },
         { path: '/youth', element: <Youth /> },
+        { path: '/transfer-market', element: <TransferMarket /> },
         { path: '/fixtures', element: <MyFixturesPage /> },
         { path: '/my-matches', element: <MyFixturesPage /> },
         { path: '/standings', element: <StandingsPage /> },

--- a/src/services/transferMarket.ts
+++ b/src/services/transferMarket.ts
@@ -1,0 +1,155 @@
+import {
+  addDoc,
+  collection,
+  doc,
+  getDocs,
+  onSnapshot,
+  orderBy,
+  query,
+  runTransaction,
+  serverTimestamp,
+  Unsubscribe,
+  where,
+} from 'firebase/firestore';
+import { db } from './firebase';
+import { ClubTeam, Player, TransferListing } from '@/types';
+
+const COLLECTION_PATH = 'transferListings';
+
+const listingsCollection = collection(db, COLLECTION_PATH);
+
+type TransferListingDoc = Omit<TransferListing, 'id' | 'createdAt' | 'soldAt'> & {
+  createdAt?: TransferListing['createdAt'] | ReturnType<typeof serverTimestamp>;
+  soldAt?: TransferListing['soldAt'] | ReturnType<typeof serverTimestamp>;
+};
+
+type TeamDoc = Pick<ClubTeam, 'players' | 'name'>;
+
+const sanitizePrice = (price: number) => {
+  if (!Number.isFinite(price)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(price));
+};
+
+export async function createTransferListing(params: {
+  sellerId: string;
+  sellerTeamName: string;
+  player: Player;
+  price: number;
+}): Promise<void> {
+  const { sellerId, sellerTeamName, player, price } = params;
+  const normalizedPrice = sanitizePrice(price);
+  if (!player?.id) {
+    throw new Error('Oyuncu bilgisi eksik.');
+  }
+  if (normalizedPrice <= 0) {
+    throw new Error('Fiyat sıfırdan büyük olmalı.');
+  }
+
+  const existingSnap = await getDocs(
+    query(
+      listingsCollection,
+      where('sellerId', '==', sellerId),
+      where('playerId', '==', player.id),
+      where('status', '==', 'available'),
+    ),
+  );
+
+  if (!existingSnap.empty) {
+    throw new Error('Bu oyuncu zaten pazarda.');
+  }
+
+  const payload: TransferListingDoc = {
+    playerId: player.id,
+    player,
+    price: normalizedPrice,
+    sellerId,
+    sellerTeamName,
+    status: 'available',
+    createdAt: serverTimestamp(),
+  };
+
+  await addDoc(listingsCollection, payload);
+}
+
+export function listenAvailableTransferListings(
+  cb: (list: TransferListing[]) => void,
+): Unsubscribe {
+  const q = query(listingsCollection, where('status', '==', 'available'), orderBy('createdAt', 'desc'));
+  return onSnapshot(q, snapshot => {
+    const list: TransferListing[] = snapshot.docs.map(docSnap => {
+      const data = docSnap.data() as TransferListingDoc;
+      return {
+        id: docSnap.id,
+        ...data,
+      };
+    });
+    cb(list);
+  });
+}
+
+export async function purchaseTransferListing(params: {
+  listingId: string;
+  buyerId: string;
+  buyerTeamName: string;
+}): Promise<void> {
+  const { listingId, buyerId, buyerTeamName } = params;
+  const listingRef = doc(db, COLLECTION_PATH, listingId);
+
+  await runTransaction(db, async tx => {
+    const listingSnap = await tx.get(listingRef);
+    if (!listingSnap.exists()) {
+      throw new Error('İlan bulunamadı.');
+    }
+
+    const listing = listingSnap.data() as TransferListingDoc;
+    if (listing.status !== 'available') {
+      throw new Error('İlan satışta değil.');
+    }
+
+    if (listing.sellerId === buyerId) {
+      throw new Error('Kendi oyuncunu satın alamazsın.');
+    }
+
+    const sellerRef = doc(db, 'teams', listing.sellerId);
+    const buyerRef = doc(db, 'teams', buyerId);
+
+    const [sellerSnap, buyerSnap] = await Promise.all([tx.get(sellerRef), tx.get(buyerRef)]);
+
+    if (!sellerSnap.exists()) {
+      throw new Error('Satıcı takım kaydı bulunamadı.');
+    }
+
+    if (!buyerSnap.exists()) {
+      throw new Error('Alıcı takım kaydı bulunamadı.');
+    }
+
+    const sellerData = sellerSnap.data() as TeamDoc | undefined;
+    const buyerData = buyerSnap.data() as TeamDoc | undefined;
+
+    const sellerPlayers = [...(sellerData?.players ?? [])];
+    const playerIndex = sellerPlayers.findIndex(p => String(p.id) === String(listing.playerId));
+
+    if (playerIndex === -1) {
+      throw new Error('Oyuncu satıcının kadrosunda bulunamadı.');
+    }
+
+    const [player] = sellerPlayers.splice(playerIndex, 1);
+    const transferredPlayer: Player = {
+      ...player,
+      squadRole: 'reserve',
+    };
+
+    const buyerPlayers = [...(buyerData?.players ?? []), transferredPlayer];
+
+    tx.update(sellerRef, { players: sellerPlayers });
+    tx.update(buyerRef, { players: buyerPlayers });
+    tx.update(listingRef, {
+      status: 'sold',
+      buyerId,
+      buyerTeamName,
+      soldAt: serverTimestamp(),
+    });
+  });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,6 +160,20 @@ export interface FinanceRecord {
   description: string;
 }
 
+export interface TransferListing {
+  id: string;
+  playerId: string;
+  player: Player;
+  price: number;
+  sellerId: string;
+  sellerTeamName: string;
+  buyerId?: string;
+  buyerTeamName?: string;
+  status: 'available' | 'sold' | 'cancelled';
+  createdAt?: FirestoreTimestamp;
+  soldAt?: FirestoreTimestamp;
+}
+
 export interface User {
   id: string;
   username: string;


### PR DESCRIPTION
## Summary
- create a Firestore-backed transfer market service and types for player listings and purchases
- build a transfer market page with listing forms, filtering, and buy actions
- surface the new marketplace via updated routes and the main menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafd80b664832ab99ea99933a4bfeb