### PR TITLE
Fix transfer market listing auth usage

### DIFF
--- a/src/pages/TransferMarket.tsx
+++ b/src/pages/TransferMarket.tsx
@@ -184,7 +184,6 @@ export default function TransferMarket() {
     setIsListing(true);
     try {
       await createTransferListing({
-        sellerId: user.id,
         sellerTeamName: teamName || user.teamName || 'Takımım',
         player,
         price: priceValue,
@@ -216,7 +215,6 @@ export default function TransferMarket() {
     try {
       await purchaseTransferListing({
         listingId: listing.id,
-        buyerId: user.id,
         buyerTeamName: teamName || user.teamName || 'Takımım',
       });
       toast.success(`${listing.player.name} takımıza katıldı!`);


### PR DESCRIPTION
## Summary
- read the seller/buyer ids for transfer listings from the authenticated Firebase user to satisfy security rules
- update the transfer market page to use the new service signatures when creating and purchasing listings

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db08710530832abae0016498af9036