### PR TITLE
Ensure transfer listings use string player IDs

### DIFF
--- a/src/services/transferMarket.ts
+++ b/src/services/transferMarket.ts
@@ -65,9 +65,15 @@ export async function createTransferListing(params: {
     throw new Error('Bu oyuncu zaten pazarda.');
   }
 
+  const playerId = String(player.id);
+  const sanitizedPlayer: Player = {
+    ...player,
+    id: playerId,
+  };
+
   const payload: TransferListingDoc = {
-    playerId: player.id,
-    player,
+    playerId,
+    player: sanitizedPlayer,
     price: normalizedPrice,
     sellerId,
     sellerTeamName,


### PR DESCRIPTION
## Summary
- normalize transfer listing payloads to always use string-based player identifiers
- store a sanitized copy of the player record to satisfy Firestore security rule constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1935bc60832ab2c5e202c6ad4039