### PR TITLE
Fix TypeScript errors in market functions

### DIFF
--- a/src/functions/src/market.ts
+++ b/src/functions/src/market.ts
@@ -1,6 +1,11 @@
 import * as functions from 'firebase-functions/v1';
 import './_firebase.js';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import {
+  getFirestore,
+  FieldValue,
+  DocumentReference,
+  DocumentData,
+} from 'firebase-admin/firestore';
 
 const db = getFirestore();
 const LISTINGS_COLLECTION = 'transferListings';
@@ -10,7 +15,7 @@ const region = 'europe-west1';
 const isString = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0;
 
-const assertAuth = (uid: string | undefined): asserts uid is string => {
+const assertAuth: (uid: string | undefined) => asserts uid is string = uid => {
   if (!uid) {
     throw new functions.https.HttpsError('unauthenticated', 'Giriş yapmalısın.');
   }
@@ -101,7 +106,7 @@ export const marketCreateListing = functions
         throw new functions.https.HttpsError('permission-denied', 'Bu takıma erişimin yok.');
       }
 
-      let playerDocRef = db.doc(playerPath);
+      let playerDocRef: DocumentReference<DocumentData> | null = db.doc(playerPath);
       let playerDocSnap = await tx.get(playerDocRef).catch(() => null);
       let playerData: PlayerSnapshot | null = null;
       let teamPlayers: PlayerSnapshot[] | undefined;

--- a/src/functions/src/types/uuid.d.ts
+++ b/src/functions/src/types/uuid.d.ts
@@ -1,0 +1,3 @@
+declare module 'uuid' {
+  export function v4(options?: unknown): string;
+}

--- a/src/functions/tsconfig.json
+++ b/src/functions/tsconfig.json
@@ -13,7 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "lib"]
 }
 


### PR DESCRIPTION
## Summary
- add explicit typing to the market auth assertion and Firestore references to satisfy strict TypeScript checks
- allow null player document references during listing creation while preserving proper typings
- register local uuid type declarations in the functions TypeScript config so builds succeed without external packages

## Testing
- npm --prefix src/functions run build

------
https://chatgpt.com/codex/tasks/task_e_68dc1fe555ac832aa65ec29f2c068598