### PR TITLE
Add transfer budget tools and Firestore index guidance

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "indexes": [
     {
       "collectionId": "leagues",
@@ -102,6 +102,15 @@
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "pos", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionId": "transferListings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "pos", "order": "ASCENDING" },
         { "fieldPath": "overall", "order": "DESCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
@@ -123,6 +132,28 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "pos", "order": "ASCENDING" },
         { "fieldPath": "price", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionId": "transferListings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "pos", "order": "ASCENDING" },
+        { "fieldPath": "price", "order": "ASCENDING" },
+        { "fieldPath": "overall", "order": "DESCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionId": "transferListings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "pos", "order": "ASCENDING" },
+        { "fieldPath": "price", "order": "ASCENDING" },
+        { "fieldPath": "overall", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     },
@@ -133,28 +164,6 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "pos", "order": "ASCENDING" },
         { "fieldPath": "price", "order": "DESCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "pos", "order": "ASCENDING" },
-        { "fieldPath": "price", "order": "ASCENDING" },
-        { "fieldPath": "overall", "order": "DESCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "pos", "order": "ASCENDING" },
-        { "fieldPath": "price", "order": "ASCENDING" },
-        { "fieldPath": "overall", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     },

--- a/src/lib/mockTeam.ts
+++ b/src/lib/mockTeam.ts
@@ -76,6 +76,7 @@ export function makeMockTeam(id: string, name: string, manager = 'AI Coach'): Cl
     manager,
     kitHome: 'home',
     kitAway: 'away',
+    budget: 0,
     players,
   };
 }

--- a/src/services/transferMarket.ts
+++ b/src/services/transferMarket.ts
@@ -1,8 +1,11 @@
 import {
   collection,
+  doc,
   onSnapshot,
   orderBy,
   query,
+  runTransaction,
+  serverTimestamp,
   type QueryDocumentSnapshot,
   type DocumentData,
   Unsubscribe,
@@ -10,7 +13,7 @@ import {
 } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import { auth, db, functions } from './firebase';
-import { Player, TransferListing } from '@/types';
+import { Player, TransferListing, type ClubTeam } from '@/types';
 import {
   LISTINGS_PATH,
   queryActiveListings,
@@ -163,6 +166,93 @@ export function listenUserTransferListings(
   });
 }
 
+async function purchaseTransferListingClient(params: {
+  listingId: string;
+  buyerUid: string;
+  buyerTeamName: string;
+}): Promise<void> {
+  const { listingId, buyerUid, buyerTeamName } = params;
+  const listingRef = doc(db, LISTINGS_PATH, listingId);
+  const buyerTeamRef = doc(db, 'teams', buyerUid);
+
+  await runTransaction(db, async transaction => {
+    const listingSnap = await transaction.get(listingRef);
+    if (!listingSnap.exists()) {
+      throw new Error('İlan bulunamadı.');
+    }
+
+    const listingData = listingSnap.data() as TransferListingDoc;
+    const status = listingData.status ?? 'active';
+    if (status !== 'active' && status !== 'available') {
+      throw new Error('İlan satışta değil.');
+    }
+
+    const playerData = (listingData.player ?? null) as Player | null;
+    const playerId = String(listingData.playerId ?? playerData?.id ?? '');
+    if (!playerData || !playerId) {
+      throw new Error('Oyuncu bilgisi eksik.');
+    }
+
+    const price = Number(listingData.price ?? 0);
+    if (!Number.isFinite(price) || price <= 0) {
+      throw new Error('İlan fiyatı geçersiz.');
+    }
+
+    const buyerSnap = await transaction.get(buyerTeamRef);
+    if (!buyerSnap.exists()) {
+      throw new Error('Takım bilgisi bulunamadı.');
+    }
+
+    const buyerData = buyerSnap.data() as ClubTeam & { players?: Player[] };
+    const buyerBudget = Number.isFinite(buyerData?.budget) ? Number(buyerData?.budget) : 0;
+    if (buyerBudget < price) {
+      throw new Error('Bütçe yetersiz.');
+    }
+
+    const buyerPlayers = Array.isArray(buyerData?.players) ? [...(buyerData.players ?? [])] : [];
+    const hasPlayer = buyerPlayers.some(existing => existing.id === playerId);
+    const normalizedPlayer: Player = {
+      ...playerData,
+      id: playerId,
+      squadRole: playerData.squadRole ?? 'reserve',
+      market: { active: false, listingId: null },
+    };
+    const updatedBuyerPlayers = hasPlayer ? buyerPlayers : [...buyerPlayers, normalizedPlayer];
+
+    transaction.update(buyerTeamRef, {
+      players: updatedBuyerPlayers,
+      budget: buyerBudget - price,
+    });
+
+    transaction.update(listingRef, {
+      status: 'sold',
+      buyerUid,
+      buyerId: buyerUid,
+      buyerTeamName,
+      soldAt: serverTimestamp(),
+      playerId,
+    });
+
+    const sellerTeamId = listingData.teamId ?? listingData.sellerId ?? listingData.sellerUid;
+    if (sellerTeamId && sellerTeamId !== buyerUid) {
+      const sellerRef = doc(db, 'teams', sellerTeamId);
+      const sellerSnap = await transaction.get(sellerRef);
+      if (sellerSnap.exists()) {
+        const sellerData = sellerSnap.data() as ClubTeam & { players?: Player[] };
+        const sellerBudget = Number.isFinite(sellerData?.budget) ? Number(sellerData?.budget) : 0;
+        const sellerPlayers = Array.isArray(sellerData?.players)
+          ? sellerData.players.filter(existing => existing.id !== playerId)
+          : [];
+
+        transaction.update(sellerRef, {
+          budget: sellerBudget + price,
+          players: sellerPlayers,
+        });
+      }
+    }
+  });
+}
+
 export async function purchaseTransferListing(params: {
   listingId: string;
   buyerTeamName: string;
@@ -173,6 +263,7 @@ export async function purchaseTransferListing(params: {
   }
 
   const { listingId, buyerTeamName } = params;
+  const buyerUid = currentUser.uid;
 
   const fn = httpsCallable<
     { listingId: string; buyerTeamName: string },
@@ -189,6 +280,17 @@ export async function purchaseTransferListing(params: {
     }
   } catch (error) {
     const firebaseError = error as { message?: string; code?: string } | undefined;
+    const shouldFallback = firebaseError
+      ? firebaseError.code === 'functions/unimplemented' ||
+        firebaseError.code === 'functions/unavailable' ||
+        firebaseError.code === 'functions/not-found'
+      : true;
+
+    if (shouldFallback) {
+      await purchaseTransferListingClient({ listingId, buyerUid, buyerTeamName });
+      return;
+    }
+
     if (firebaseError && typeof firebaseError.code === 'string') {
       throw new Error(firebaseError.message || 'Satın alma başarısız.');
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,7 @@ export interface ClubTeam {
   manager: string;
   kitHome: string;
   kitAway: string;
+  budget?: number;
   players: Player[];
   plan?: {
     formation: string;


### PR DESCRIPTION
## Summary
- add transfer budget card, budget checks, and detailed Firestore index guidance on the Transfer Market page
- support client-side purchase fallback that updates team rosters and budgets while exposing a reusable budget adjustment helper
- expand the Firestore composite indexes for transfer listings and persist team budgets across mock data and types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc3a5440e8832aa767a93f897df43d