### PR TITLE
Fix transfer market Firestore queries and indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "collectionId": "transferListings",
+      "collectionGroup": "transferListings",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
@@ -41,7 +41,7 @@
       ]
     },
     {
-      "collectionId": "transferListings",
+      "collectionGroup": "transferListings",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
@@ -50,16 +50,7 @@
       ]
     },
     {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "overall", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
+      "collectionGroup": "transferListings",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
@@ -68,36 +59,7 @@
       ]
     },
     {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "price", "order": "DESCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "price", "order": "ASCENDING" },
-        { "fieldPath": "overall", "order": "DESCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "price", "order": "ASCENDING" },
-        { "fieldPath": "overall", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
+      "collectionGroup": "transferListings",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
@@ -106,7 +68,7 @@
       ]
     },
     {
-      "collectionId": "transferListings",
+      "collectionGroup": "transferListings",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
@@ -116,17 +78,7 @@
       ]
     },
     {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "pos", "order": "ASCENDING" },
-        { "fieldPath": "overall", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
+      "collectionGroup": "transferListings",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
@@ -136,35 +88,13 @@
       ]
     },
     {
-      "collectionId": "transferListings",
+      "collectionGroup": "transferListings",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "pos", "order": "ASCENDING" },
         { "fieldPath": "price", "order": "ASCENDING" },
-        { "fieldPath": "overall", "order": "DESCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "pos", "order": "ASCENDING" },
-        { "fieldPath": "price", "order": "ASCENDING" },
-        { "fieldPath": "overall", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
-    },
-    {
-      "collectionId": "transferListings",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "pos", "order": "ASCENDING" },
-        { "fieldPath": "price", "order": "DESCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
+        { "fieldPath": "overall", "order": "DESCENDING" }
       ]
     },
     {

--- a/firestore.rules
+++ b/firestore.rules
@@ -36,8 +36,8 @@ service cloud.firestore {
     }
 
     match /transferListings/{listingId} {
-      allow read: if isSignedIn();
-      allow create, update, delete: if false;
+      allow read: if request.auth != null;
+      allow write: if false;
     }
 
     match /leagues/{leagueId} {

--- a/src/functions/src/market.ts
+++ b/src/functions/src/market.ts
@@ -22,13 +22,14 @@ const assertAuth: (uid: string | undefined) => asserts uid is string = uid => {
 };
 
 const normalizePrice = (price: unknown): number => {
-  if (typeof price !== 'number') {
+  const numeric = Number(price);
+  if (!Number.isFinite(numeric)) {
     throw new functions.https.HttpsError('invalid-argument', 'Geçerli bir fiyat belirt.');
   }
-  if (!Number.isFinite(price) || price <= 0) {
+  if (numeric <= 0) {
     throw new functions.https.HttpsError('invalid-argument', 'Fiyat sıfırdan büyük olmalı.');
   }
-  return Math.round(price);
+  return Math.round(numeric);
 };
 
 type PlayerSnapshot = Record<string, unknown> & {


### PR DESCRIPTION
## Summary
- add a reusable Firestore query builder for transfer listings and update marketplace listeners to use it
- coerce listing prices to numbers, tighten marketplace Firestore rules, and refresh composite indexes
- improve transfer market error handling with a dev-only index creation prompt

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4144015c832aa33ea730ab216456