### PR TITLE
Implement atomic transfer purchase flow

### DIFF
--- a/src/functions/lib/index.js
+++ b/src/functions/lib/index.js
@@ -4,6 +4,7 @@ export { orchestrate19TRT } from './orchestrate/orchestrate19trt.js';
 export { startMatchHttp } from './orchestrate/startMatch.js';
 export { onResultFinalize } from './results/onResultFinalize.js';
 export { getReplay } from './results/getReplay.js';
+export { marketCreateListing, marketCancelListing, marketPurchaseListing, } from './market.js';
 // Plan 4: Sözleşmeler (React ⇄ Functions ⇄ Unity)
 // League onboarding & fixtures management
 export { assignTeamToLeague, assignTeamToLeagueHttp, requestJoinLeague, finalizeIfFull, generateRoundRobinFixturesFn, assignAllTeamsToLeagues, } from './league.js';

--- a/src/pages/TransferMarket.tsx
+++ b/src/pages/TransferMarket.tsx
@@ -177,7 +177,12 @@ export default function TransferMarket() {
       const team = await getTeam(user.id);
       setTeamPlayers(team?.players ?? []);
       setTeamName(team?.name ?? user.teamName ?? 'Takımım');
-      setTeamBudget(Number.isFinite(team?.budget) ? Number(team?.budget) : 0);
+      const nextBudget = Number.isFinite(team?.transferBudget)
+        ? Number(team?.transferBudget)
+        : Number.isFinite(team?.budget)
+          ? Number(team?.budget)
+          : 0;
+      setTeamBudget(nextBudget);
     } catch (error) {
       console.error('[TransferMarket] takımı yükleme hatası', error);
       toast.error('Takım bilgileri alınamadı.', {
@@ -382,10 +387,7 @@ export default function TransferMarket() {
 
     setPurchasingId(listing.id);
     try {
-      await purchaseTransferListing({
-        listingId: listing.id,
-        buyerTeamName: teamName || user.teamName || 'Takımım',
-      });
+      await purchaseTransferListing(listing.id, user.id);
       toast.success(`${listing.player.name} takımıza katıldı!`);
       setTeamBudget(prev => Math.max(0, prev - listing.price));
       await loadTeam();

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -72,6 +72,7 @@ const generateTeamData = (id: string, name: string, manager: string): ClubTeam =
     kitHome: 'home',
     kitAway: 'away',
     budget: 0,
+    transferBudget: 0,
     players,
   };
 };
@@ -104,10 +105,14 @@ export const adjustTeamBudget = async (userId: string, amount: number): Promise<
     }
 
     const data = snapshot.data() as ClubTeam | undefined;
-    const currentBudget = Number.isFinite(data?.budget) ? Number(data?.budget) : 0;
+    const currentBudget = Number.isFinite(data?.transferBudget)
+      ? Number(data?.transferBudget)
+      : Number.isFinite(data?.budget)
+        ? Number(data?.budget)
+        : 0;
     const nextBudget = Math.max(0, Math.round(currentBudget + amount));
 
-    transaction.update(teamRef, { budget: nextBudget });
+    transaction.update(teamRef, { budget: nextBudget, transferBudget: nextBudget });
     return nextBudget;
   });
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,7 +58,9 @@ export interface ClubTeam {
   manager: string;
   kitHome: string;
   kitAway: string;
+  /** @deprecated use transferBudget */
   budget?: number;
+  transferBudget?: number;
   players: Player[];
   plan?: {
     formation: string;


### PR DESCRIPTION
## Summary
- add an atomic `marketPurchaseListing` callable that validates availability, budgets, and moves the player and funds within a single transaction
- surface structured purchase errors on the client and call the europe-west1 callable with an idempotent payload while disabling the buy button during the request
- store transfer budgets on teams and prefer them throughout the UI to keep client state in sync with server updates

## Testing
- npm run build (functions)
- npm run lint *(fails: repository already contains hundreds of lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc473c315c832ab970d8f791031601