### PR TITLE
Enable custom team name during social registration

### DIFF
--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -96,6 +96,14 @@ export const getTeam = async (userId: string): Promise<ClubTeam | null> => {
   return snap.exists() ? (snap.data() as ClubTeam) : null;
 };
 
+export const updateTeamName = async (userId: string, teamName: string) => {
+  await setDoc(
+    doc(db, 'teams', userId),
+    { name: teamName },
+    { merge: true },
+  );
+};
+
 export const adjustTeamBudget = async (userId: string, amount: number): Promise<number> => {
   const teamRef = doc(db, 'teams', userId);
   return runTransaction(db, async transaction => {


### PR DESCRIPTION
## Summary
- prompt Google and Apple sign-ups for a custom team name instead of defaulting to provider data
- add a modal on the registration tab so social users enter their club name before completing auth
- update the auth flow to create or rename the team document with the chosen name when using social providers

## Testing
- npm run lint *(fails: existing lint errors across unrelated files, including legacy any types and empty blocks)*

------
https://chatgpt.com/codex/tasks/task_e_68dc51452848832aa816630f36a15325