### PR TITLE
Enhance team planning lineup and transfer flows

### DIFF
--- a/src/components/ui/player-card.tsx
+++ b/src/components/ui/player-card.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { calculatePowerIndex } from '@/lib/player';
@@ -22,6 +23,8 @@ interface PlayerCardProps {
   onMoveToBench?: () => void;
   onMoveToReserve?: () => void;
   onPromoteToTeam?: () => void;
+  onListForTransfer?: () => void;
+  onReleasePlayer?: () => void;
   showActions?: boolean;
   compact?: boolean;
   defaultCollapsed?: boolean;
@@ -51,6 +54,8 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
   onMoveToBench,
   onMoveToReserve,
   onPromoteToTeam,
+  onListForTransfer,
+  onReleasePlayer,
   showActions = true,
   compact = false,
   defaultCollapsed = false,
@@ -237,6 +242,13 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
                   )}
                   {player.squadRole !== 'reserve' && onMoveToReserve && (
                     <DropdownMenuItem onClick={onMoveToReserve}>Rezerve Al</DropdownMenuItem>
+                  )}
+                  {(onListForTransfer || onReleasePlayer) && <DropdownMenuSeparator />}
+                  {onListForTransfer && (
+                    <DropdownMenuItem onClick={onListForTransfer}>Oyuncuyu Pazara Koy</DropdownMenuItem>
+                  )}
+                  {onReleasePlayer && (
+                    <DropdownMenuItem onClick={onReleasePlayer}>Serbest Bırak</DropdownMenuItem>
                   )}
                   {player.squadRole === 'youth' && onPromoteToTeam && (
                     <DropdownMenuItem onClick={onPromoteToTeam}>Takıma Al</DropdownMenuItem>


### PR DESCRIPTION
## Summary
- enforce the 11-player limit for the starting squad by swapping same-position players and blocking overflow moves
- add reserve card actions for listing a player on the market or releasing them directly from team planning
- auto-select the chosen reserve player on the transfer market page when navigating from team planning so only the price is required

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7af50a90832aaeca36f8a13cc838