### PR TITLE
Enable manual formation placement and bench suggestions

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,17 @@ export interface Player {
   } | null;
 }
 
+export type CustomFormationLayout = Record<
+  string,
+  {
+    x: number;
+    y: number;
+    position: Position;
+  }
+>;
+
+export type CustomFormationMap = Record<string, CustomFormationLayout>;
+
 export interface ClubTeam {
   id: string;
   name: string;
@@ -68,6 +79,7 @@ export interface ClubTeam {
     bench: string[];
     reserves: string[];
     updatedAt?: string;
+    customFormations?: CustomFormationMap;
   };
   lineup?: {
     formation?: string;
@@ -76,6 +88,7 @@ export interface ClubTeam {
     subs?: string[];
     reserves?: string[];
     updatedAt?: string;
+    customFormations?: CustomFormationMap;
   };
 }
 

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -1,9 +1,12 @@
+import type { CustomFormationMap } from '@/types';
+
 export interface Lineup {
   formation: string;          // e.g. "4-3-3"
   starters: string[];         // playerId[]
   subs: string[];             // playerId[]
   reserves?: string[];        // optional reserve list for UI snapshots
   tactics?: Record<string, any>;
+  customFormations?: CustomFormationMap;
 }
 
 export interface TeamDoc {


### PR DESCRIPTION
## Summary
- allow managers to drag players freely on the pitch and persist manual coordinates per formation
- persist custom formation layouts inside saved team plans and lineups
- display player names plus bench/reserve alternatives in the formation view with a stat dialog

## Testing
- npm run lint *(fails because of existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7dd50ebc832a8527559c7bdd4b3f