### PR TITLE
feat: improve manual formation display and alternatives

### DIFF
--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -136,6 +136,7 @@ export const adjustTeamBudget = async (userId: string, amount: number): Promise<
 
 type TeamPlanUpdate = {
   formation?: string;
+  shape?: string;
   tactics?: Record<string, unknown>;
   squads?: {
     starters?: string[];
@@ -149,7 +150,7 @@ export const saveTeamPlayers = async (userId: string, players: Player[], plan?: 
   const payload: Record<string, unknown> = { players };
 
   if (plan) {
-    const { formation, squads, tactics, customFormations } = plan;
+    const { formation, shape, squads, tactics, customFormations } = plan;
     const dedupe = (list?: string[]) =>
       Array.from(new Set((list ?? []).map(id => String(id)))).filter(Boolean);
 
@@ -157,6 +158,11 @@ export const saveTeamPlayers = async (userId: string, players: Player[], plan?: 
       typeof formation === 'string' && formation.trim().length > 0
         ? formation.trim()
         : 'auto';
+
+    const sanitizedShape =
+      typeof shape === 'string' && shape.trim().length > 0
+        ? shape.trim()
+        : undefined;
 
     const sanitizedSquads = {
       starters: dedupe(squads?.starters),
@@ -233,6 +239,7 @@ export const saveTeamPlayers = async (userId: string, players: Player[], plan?: 
       bench: sanitizedSquads.bench,
       reserves: sanitizedSquads.reserves,
       updatedAt: timestamp,
+      ...(sanitizedShape ? { shape: sanitizedShape } : {}),
       ...(sanitizedCustomFormations ? { customFormations: sanitizedCustomFormations } : {}),
     };
 
@@ -243,6 +250,7 @@ export const saveTeamPlayers = async (userId: string, players: Player[], plan?: 
       subs: sanitizedSquads.bench,
       reserves: sanitizedSquads.reserves,
       updatedAt: timestamp,
+      ...(sanitizedShape ? { shape: sanitizedShape } : {}),
       ...(sanitizedCustomFormations ? { customFormations: sanitizedCustomFormations } : {}),
     };
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,7 @@ export interface ClubTeam {
     starters: string[];
     bench: string[];
     reserves: string[];
+    shape?: string;
     updatedAt?: string;
     customFormations?: CustomFormationMap;
   };
@@ -87,6 +88,7 @@ export interface ClubTeam {
     starters?: string[];
     subs?: string[];
     reserves?: string[];
+    shape?: string;
     updatedAt?: string;
     customFormations?: CustomFormationMap;
   };


### PR DESCRIPTION
## Summary
- derive the active formation shape from manual player placements and persist it with the saved plan
- surface the computed manual shape in the team planning header while keeping the selected template context
- show eligible bench and reserve alternatives under the pitch with reusable bubbles that open their status cards

## Testing
- pnpm lint *(fails: existing lint rules flag many @typescript-eslint/no-explicit-any and no-empty violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8a498dbc832a9553fb6de8bb9d10