### PR TITLE
Add kit management system and injury-aware players

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/contexts/AuthContext';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { DiamondProvider } from '@/contexts/DiamondContext';
 import { router } from '@/routes/router';
+import { InventoryProvider } from '@/contexts/InventoryContext';
 
 const queryClient = new QueryClient();
 
@@ -14,13 +15,15 @@ const App = () => (
     <ThemeProvider>
       <AuthProvider>
         <DiamondProvider>
-          <TooltipProvider>
-            <Toaster />
-            <RouterProvider
-              router={router}
-              future={{ v7_startTransition: true }} // v7 uyarısını burada sustur
-            />
-          </TooltipProvider>
+          <InventoryProvider>
+            <TooltipProvider>
+              <Toaster />
+              <RouterProvider
+                router={router}
+                future={{ v7_startTransition: true }} // v7 uyarısını burada sustur
+              />
+            </TooltipProvider>
+          </InventoryProvider>
         </DiamondProvider>
       </AuthProvider>
     </ThemeProvider>

--- a/src/components/kit/KitUsageDialog.tsx
+++ b/src/components/kit/KitUsageDialog.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Loader2, Search } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Progress } from '@/components/ui/progress';
+import { useAuth } from '@/contexts/AuthContext';
+import { useInventory } from '@/contexts/InventoryContext';
+import type { KitType, Player } from '@/types';
+import { KIT_CONFIG, formatKitEffect } from '@/lib/kits';
+import { getTeam } from '@/services/team';
+
+type KitUsageDialogProps = {
+  open: boolean;
+  kitType: KitType | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+const gaugePercentage = (value?: number | null): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.round(Math.min(1, Math.max(0, value)) * 100);
+  }
+  return 75;
+};
+
+const normalizePlayers = (players: Player[]): Player[] =>
+  players.map((player) => ({ ...player, injuryStatus: player.injuryStatus ?? 'healthy' }));
+
+const KitUsageDialog = ({ open, kitType, onOpenChange }: KitUsageDialogProps) => {
+  const { user } = useAuth();
+  const { kits, applyKitToPlayer, isProcessing } = useInventory();
+  const [search, setSearch] = useState('');
+  const [submittingPlayerId, setSubmittingPlayerId] = useState<string | null>(null);
+
+  const { data: players = [], isLoading, refetch } = useQuery({
+    queryKey: ['team-players', user?.id],
+    queryFn: async () => {
+      if (!user) return [];
+      const team = await getTeam(user.id);
+      if (!team?.players) return [];
+      return normalizePlayers(team.players);
+    },
+    enabled: open && Boolean(user) && Boolean(kitType),
+    staleTime: 10_000,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setSearch('');
+      setSubmittingPlayerId(null);
+    }
+  }, [open]);
+
+  const filteredPlayers = useMemo(() => {
+    if (!kitType) return [];
+    const term = search.trim().toLowerCase();
+
+    const list = players.filter((player) =>
+      term.length === 0 ? true : player.name.toLowerCase().includes(term),
+    );
+
+    const byCondition = (value: Player) => gaugePercentage(value.condition);
+    const byMotivation = (value: Player) => gaugePercentage(value.motivation);
+
+    return list.sort((a, b) => {
+      if (kitType === 'health') {
+        const aInjured = a.injuryStatus === 'injured' ? 0 : 1;
+        const bInjured = b.injuryStatus === 'injured' ? 0 : 1;
+        if (aInjured !== bInjured) {
+          return aInjured - bInjured;
+        }
+        return byCondition(a) - byCondition(b);
+      }
+
+      if (kitType === 'energy') {
+        return byCondition(a) - byCondition(b);
+      }
+
+      return byMotivation(a) - byMotivation(b);
+    });
+  }, [players, search, kitType]);
+
+  const handleApply = async (playerId: string) => {
+    if (!kitType) return;
+    setSubmittingPlayerId(playerId);
+    try {
+      await applyKitToPlayer(kitType, playerId);
+      await refetch();
+      onOpenChange(false);
+    } catch (error) {
+      console.warn('[KitUsageDialog] apply kit failed', error);
+    } finally {
+      setSubmittingPlayerId(null);
+    }
+  };
+
+  const activeConfig = kitType ? KIT_CONFIG[kitType] : null;
+  const remaining = kitType ? kits[kitType] ?? 0 : 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>
+            {kitType ? `${activeConfig?.label} Kullan` : 'Kit Seç'}
+          </DialogTitle>
+          {kitType && (
+            <DialogDescription className="space-y-1">
+              <span>{activeConfig?.description}</span>
+              {kitType && (
+                <div className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                  {formatKitEffect(kitType)}
+                </div>
+              )}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {!kitType && (
+          <p className="py-6 text-sm text-muted-foreground">
+            Lütfen önce kullanmak istediğiniz kiti seçin.
+          </p>
+        )}
+
+        {kitType && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between text-sm">
+              <span>Kalan stok:</span>
+              <Badge variant={remaining > 0 ? 'secondary' : 'outline'}>{remaining}</Badge>
+            </div>
+
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Oyuncu ara"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                className="pl-9"
+              />
+            </div>
+
+            <ScrollArea className="max-h-80 pr-2">
+              {isLoading ? (
+                <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Oyuncular yükleniyor...
+                </div>
+              ) : filteredPlayers.length === 0 ? (
+                <div className="py-10 text-center text-sm text-muted-foreground">
+                  Uygun oyuncu bulunamadı.
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {filteredPlayers.map((player) => {
+                    const condition = gaugePercentage(player.condition);
+                    const motivation = gaugePercentage(player.motivation);
+                    const isSubmitting = submittingPlayerId === player.id && isProcessing;
+
+                    return (
+                      <div
+                        key={player.id}
+                        className="rounded-lg border bg-card p-3 shadow-sm transition hover:border-primary/40"
+                      >
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div className="space-y-1">
+                            <div className="text-sm font-semibold">{player.name}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {player.position} • Kondisyon %{condition} • Motivasyon %{motivation}
+                            </div>
+                            <div className="flex flex-wrap gap-2 pt-1">
+                              <Badge variant="outline">Güç {Math.round(player.overall * 100)}</Badge>
+                              {player.injuryStatus === 'injured' && (
+                                <Badge variant="destructive">Sakat</Badge>
+                              )}
+                            </div>
+                          </div>
+                          <Button
+                            size="sm"
+                            disabled={remaining === 0 || isProcessing}
+                            onClick={() => handleApply(player.id)}
+                          >
+                            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            Kiti Kullan
+                          </Button>
+                        </div>
+
+                        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                          <div>
+                            <div className="mb-1 text-xs font-medium text-muted-foreground">
+                              Kondisyon %{condition}
+                            </div>
+                            <Progress value={condition} className="h-2" />
+                          </div>
+                          <div>
+                            <div className="mb-1 text-xs font-medium text-muted-foreground">
+                              Motivasyon %{motivation}
+                            </div>
+                            <Progress value={motivation} className="h-2" />
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </ScrollArea>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default KitUsageDialog;

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,27 +1,132 @@
-import { Diamond, Plus } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import {
+  BatteryCharging,
+  Diamond,
+  HeartPulse,
+  Loader2,
+  Plus,
+  Smile,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useDiamonds } from '@/contexts/DiamondContext';
+import { useInventory } from '@/contexts/InventoryContext';
+import type { KitType } from '@/types';
+import { KIT_CONFIG, formatKitEffect } from '@/lib/kits';
+import KitUsageDialog from '@/components/kit/KitUsageDialog';
+import { toast } from 'sonner';
+
+const KIT_ICONS: Record<KitType, { icon: LucideIcon; color: string }> = {
+  energy: { icon: BatteryCharging, color: 'text-emerald-500' },
+  morale: { icon: Smile, color: 'text-amber-500' },
+  health: { icon: HeartPulse, color: 'text-rose-500' },
+};
 
 const TopBar = () => {
-  const { balance } = useDiamonds();
   const navigate = useNavigate();
+  const { balance } = useDiamonds();
+  const { kits, purchaseKit, isProcessing } = useInventory();
+  const [activeKit, setActiveKit] = useState<KitType | null>(null);
+  const [isUsageOpen, setIsUsageOpen] = useState(false);
+
+  const handlePurchase = async (type: KitType, method: 'ad' | 'diamonds') => {
+    try {
+      await purchaseKit(type, method);
+    } catch (error) {
+      // errors are surfaced through toasts inside the provider
+      console.warn('[TopBar] purchase kit failed', error);
+    }
+  };
+
+  const handleUse = (type: KitType) => {
+    if ((kits[type] ?? 0) <= 0) {
+      toast.error('Stokta yeterli kit bulunmuyor.');
+      return;
+    }
+    setActiveKit(type);
+    setIsUsageOpen(true);
+  };
+
+  const handleUsageOpenChange = (open: boolean) => {
+    setIsUsageOpen(open);
+    if (!open) {
+      setActiveKit(null);
+    }
+  };
 
   return (
-    <div className="flex justify-end items-center p-4 border-b">
-      <div className="flex items-center gap-1" data-testid="topbar-diamond-balance">
-        <Diamond className="h-5 w-5 text-blue-500" />
-        <span>{balance}</span>
+    <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-background/60 p-4 backdrop-blur-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        {(Object.keys(KIT_ICONS) as KitType[]).map((type) => {
+          const { icon: Icon, color } = KIT_ICONS[type];
+          const count = kits[type] ?? 0;
+          const config = KIT_CONFIG[type];
+          const effectText = formatKitEffect(type);
+
+          return (
+            <DropdownMenu key={type}>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm" className="flex items-center gap-2">
+                  <Icon className={`h-4 w-4 ${color}`} />
+                  <span className="text-sm font-medium">{config.label}</span>
+                  <Badge variant={count > 0 ? 'secondary' : 'outline'}>{count}</Badge>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-64">
+                <DropdownMenuLabel>{config.label}</DropdownMenuLabel>
+                <p className="px-2 text-xs text-muted-foreground">{config.description}</p>
+                {effectText && (
+                  <p className="px-2 pb-2 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                    {effectText}
+                  </p>
+                )}
+                <DropdownMenuItem disabled={isProcessing} onClick={() => handlePurchase(type, 'ad')}>
+                  Reklam İzle (+{config.adReward})
+                </DropdownMenuItem>
+                <DropdownMenuItem disabled={isProcessing} onClick={() => handlePurchase(type, 'diamonds')}>
+                  {config.diamondCost} Elmas ile Satın Al
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  disabled={count === 0 || isProcessing}
+                  onClick={() => handleUse(type)}
+                >
+                  {count === 0 ? 'Stok Yok' : 'Kiti Kullan'}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          );
+        })}
       </div>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="ml-2"
-        onClick={() => navigate('/store/diamonds')}
-        data-testid="topbar-diamond-plus"
-      >
-        <Plus className="h-4 w-4" />
-      </Button>
+
+      <div className="ml-auto flex items-center gap-2">
+        {isProcessing && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+        <div className="flex items-center gap-1" data-testid="topbar-diamond-balance">
+          <Diamond className="h-5 w-5 text-blue-500" />
+          <span>{balance}</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigate('/store/diamonds')}
+          data-testid="topbar-diamond-plus"
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <KitUsageDialog open={isUsageOpen} kitType={activeKit} onOpenChange={handleUsageOpenChange} />
     </div>
   );
 };

--- a/src/components/ui/player-card.tsx
+++ b/src/components/ui/player-card.tsx
@@ -197,6 +197,11 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
                 <Badge variant="secondary" className={cn('text-xs', compact && 'text-[10px]')}>
                   {player.age} yaş
                 </Badge>
+                {player.injuryStatus === 'injured' && (
+                  <Badge variant="destructive" className={cn('text-xs', compact && 'text-[10px]')}>
+                    Sakat
+                  </Badge>
+                )}
                 <div className={cn('flex items-center gap-1 text-muted-foreground', compact && 'gap-0.5')}>
                   <TrendingUp className={cn('h-3 w-3', compact && 'h-2.5 w-2.5')} />
                   <Tooltip>

--- a/src/components/ui/player-status-card.tsx
+++ b/src/components/ui/player-status-card.tsx
@@ -72,6 +72,11 @@ export function PlayerStatusCard({ player, className }: PlayerStatusCardProps) {
             <Badge variant="outline" className="text-[11px]">
               Potansiyel {Math.round(player.potential * 100)}
             </Badge>
+            {player.injuryStatus === 'injured' && (
+              <Badge variant="destructive" className="text-[11px]">
+                Sakat
+              </Badge>
+            )}
             {player.roles?.map(role => (
               <Badge key={role} variant="outline" className="text-[11px]">
                 {role}

--- a/src/contexts/InventoryContext.tsx
+++ b/src/contexts/InventoryContext.tsx
@@ -1,0 +1,193 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { useDiamonds } from '@/contexts/DiamondContext';
+import type { KitType, Player } from '@/types';
+import { KIT_CONFIG } from '@/lib/kits';
+import { getTeam, saveTeamPlayers } from '@/services/team';
+
+export type KitInventory = Record<KitType, number>;
+export type KitPurchaseMethod = 'ad' | 'diamonds';
+
+interface InventoryContextValue {
+  kits: KitInventory;
+  purchaseKit: (type: KitType, method: KitPurchaseMethod) => Promise<void>;
+  applyKitToPlayer: (type: KitType, playerId: string) => Promise<void>;
+  isProcessing: boolean;
+}
+
+const DEFAULT_INVENTORY: KitInventory = {
+  energy: 0,
+  morale: 0,
+  health: 0,
+};
+
+const DEFAULT_GAUGE = 0.75;
+
+const clampGauge = (value: number): number => {
+  if (!Number.isFinite(value)) return DEFAULT_GAUGE;
+  const normalized = Number(value.toFixed(3));
+  if (normalized < 0) return 0;
+  if (normalized > 1) return 1;
+  return normalized;
+};
+
+const readGauge = (value: number | undefined | null): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  return DEFAULT_GAUGE;
+};
+
+const InventoryContext = createContext<InventoryContextValue | undefined>(undefined);
+
+export const InventoryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user } = useAuth();
+  const { spend } = useDiamonds();
+  const [kits, setKits] = useState<KitInventory>(DEFAULT_INVENTORY);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const storageKey = user ? `kits:${user.id}` : null;
+
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') {
+      if (!user) {
+        setKits(DEFAULT_INVENTORY);
+      }
+      return;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) {
+        setKits(DEFAULT_INVENTORY);
+        return;
+      }
+      const parsed = JSON.parse(raw) as Partial<KitInventory> | null;
+      setKits({ ...DEFAULT_INVENTORY, ...(parsed ?? {}) });
+    } catch (error) {
+      console.warn('[InventoryProvider] failed to read kits', error);
+      setKits(DEFAULT_INVENTORY);
+    }
+  }, [storageKey, user]);
+
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(kits));
+    } catch (error) {
+      console.warn('[InventoryProvider] failed to persist kits', error);
+    }
+  }, [kits, storageKey]);
+
+  const purchaseKit = useCallback(async (type: KitType, method: KitPurchaseMethod) => {
+    if (!user) {
+      toast.error('Kit satın almak için giriş yapmalısın.');
+      throw new Error('auth-required');
+    }
+
+    const config = KIT_CONFIG[type];
+    setIsProcessing(true);
+
+    try {
+      const gained = method === 'diamonds' ? 1 : config.adReward;
+      if (method === 'diamonds') {
+        await spend(config.diamondCost);
+        toast.success(`${config.label} satın alındı.`);
+      } else {
+        toast.success(`Reklam ödülü: +${gained} ${config.label}.`);
+      }
+
+      setKits((prev) => ({
+        ...prev,
+        [type]: (prev[type] ?? 0) + gained,
+      }));
+    } catch (error) {
+      if (method === 'diamonds') {
+        console.warn('[InventoryProvider] diamond purchase failed', error);
+      }
+      if (error instanceof Error && error.message !== 'auth-required') {
+        toast.error(error.message || 'Kit satın alınamadı.');
+      }
+      throw error;
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [spend, user]);
+
+  const applyKitToPlayer = useCallback(async (type: KitType, playerId: string) => {
+    if (!user) {
+      toast.error('Kit kullanmak için giriş yapmalısın.');
+      throw new Error('auth-required');
+    }
+
+    const available = kits[type] ?? 0;
+    if (available <= 0) {
+      toast.error('Bu kitten stoğunuz kalmadı.');
+      return;
+    }
+
+    setIsProcessing(true);
+
+    try {
+      const team = await getTeam(user.id);
+      if (!team || !Array.isArray(team.players)) {
+        throw new Error('Takım bulunamadı.');
+      }
+
+      const index = team.players.findIndex((player) => String(player.id) === String(playerId));
+      if (index === -1) {
+        throw new Error('Oyuncu bulunamadı.');
+      }
+
+      const player = team.players[index] as Player;
+      const config = KIT_CONFIG[type];
+
+      const nextPlayer: Player = {
+        ...player,
+        condition: clampGauge(readGauge(player.condition) + config.conditionDelta),
+        motivation: clampGauge(readGauge(player.motivation) + config.motivationDelta),
+        injuryStatus: config.healsInjury ? 'healthy' : player.injuryStatus ?? 'healthy',
+      };
+
+      const updatedPlayers = [...team.players];
+      updatedPlayers[index] = nextPlayer;
+
+      await saveTeamPlayers(user.id, updatedPlayers);
+
+      setKits((prev) => ({
+        ...prev,
+        [type]: Math.max(0, (prev[type] ?? 0) - 1),
+      }));
+
+      toast.success(`${config.label} ${player.name} için uygulandı.`);
+    } catch (error) {
+      console.warn('[InventoryProvider] apply kit failed', error);
+      if (error instanceof Error && error.message !== 'auth-required') {
+        toast.error(error.message || 'Kit kullanılamadı.');
+      }
+      throw error;
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [kits, user]);
+
+  const value = useMemo<InventoryContextValue>(() => ({
+    kits,
+    purchaseKit,
+    applyKitToPlayer,
+    isProcessing,
+  }), [kits, purchaseKit, applyKitToPlayer, isProcessing]);
+
+  return <InventoryContext.Provider value={value}>{children}</InventoryContext.Provider>;
+};
+
+export const useInventory = (): InventoryContextValue => {
+  const context = useContext(InventoryContext);
+  if (!context) {
+    throw new Error('useInventory must be used within InventoryProvider');
+  }
+  return context;
+};

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -21,7 +21,7 @@ const createAttributes = (attrs: Partial<Player['attributes']>): Player['attribu
 });
 
 const defaultPhysical = { height: 180, weight: 75 };
-const defaultVitals = { condition: 0.82, motivation: 0.78 };
+const defaultVitals = { condition: 0.82, motivation: 0.78, injuryStatus: 'healthy' as const };
 
 const rawMockPlayers: Omit<Player, 'potential'>[] = [
   {

--- a/src/lib/kits.ts
+++ b/src/lib/kits.ts
@@ -1,0 +1,54 @@
+import type { KitType } from '@/types';
+
+export type KitConfig = {
+  label: string;
+  description: string;
+  diamondCost: number;
+  adReward: number;
+  conditionDelta: number;
+  motivationDelta: number;
+  healsInjury: boolean;
+};
+
+export const KIT_CONFIG: Record<KitType, KitConfig> = {
+  energy: {
+    label: 'Enerji Kiti',
+    description: 'Seçilen oyuncunun kondisyonunu hızla yeniler ve hafif moral desteği sağlar.',
+    diamondCost: 35,
+    adReward: 1,
+    conditionDelta: 0.2,
+    motivationDelta: 0.05,
+    healsInjury: false,
+  },
+  morale: {
+    label: 'Moral Kiti',
+    description: 'Oyuncunun moralini yükseltir, kondisyonuna küçük bir takviye verir.',
+    diamondCost: 30,
+    adReward: 1,
+    conditionDelta: 0.05,
+    motivationDelta: 0.2,
+    healsInjury: false,
+  },
+  health: {
+    label: 'Sağlık Kiti',
+    description: 'Sakatlıkları tedavi eder, kondisyon ve moral değerlerini dengeli şekilde artırır.',
+    diamondCost: 60,
+    adReward: 1,
+    conditionDelta: 0.15,
+    motivationDelta: 0.1,
+    healsInjury: true,
+  },
+};
+
+export const formatKitEffect = (type: KitType): string => {
+  const config = KIT_CONFIG[type];
+  const conditionPct = Math.round(config.conditionDelta * 100);
+  const motivationPct = Math.round(config.motivationDelta * 100);
+  const boosts = [
+    conditionPct ? `+%${conditionPct} kondisyon` : null,
+    motivationPct ? `+%${motivationPct} motivasyon` : null,
+    config.healsInjury ? 'Sakatlığı tamamen iyileştirir' : null,
+  ].filter(Boolean);
+
+  return boosts.length > 0 ? boosts.join(' • ') : '';
+};

--- a/src/lib/mockTeam.ts
+++ b/src/lib/mockTeam.ts
@@ -53,6 +53,7 @@ function makePlayer(id: number, forced?: Position): Player {
     squadRole: 'reserve',
     condition: parseFloat((0.6 + Math.random() * 0.4).toFixed(3)),
     motivation: parseFloat((0.55 + Math.random() * 0.45).toFixed(3)),
+    injuryStatus: 'healthy',
   };
 }
 

--- a/src/lib/player.test.ts
+++ b/src/lib/player.test.ts
@@ -34,6 +34,7 @@ test('assigns max stats based on roles without exceeding potential', () => {
     weight: 75,
     condition: 0.8,
     motivation: 0.8,
+    injuryStatus: 'healthy',
     squadRole: 'starting',
   };
 

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -93,7 +93,9 @@ export function calculatePowerIndex(player: Player): number {
   const motivation = clamp01(player.motivation ?? 0.75);
   const physical = (player.attributes.strength + player.attributes.shootPower + player.attributes.topSpeed) / 3;
   const technical = (player.attributes.ballControl + player.attributes.passing + player.attributes.agility) / 3;
-  const rating = (player.overall + physical + technical + condition + motivation) / 5;
-  return parseFloat(rating.toFixed(3));
+  const baseRating = (player.overall + physical + technical + condition + motivation) / 5;
+  const injuryPenalty = player.injuryStatus === 'injured' ? 0.1 : 0;
+  const adjusted = Math.max(0, baseRating - injuryPenalty);
+  return parseFloat(adjusted.toFixed(3));
 }
 

--- a/src/pages/TeamPlanning.tsx
+++ b/src/pages/TeamPlanning.tsx
@@ -161,6 +161,7 @@ function normalizePlayer(player: Player): Player {
     ...player,
     condition: clampPerformanceGauge(player.condition, DEFAULT_GAUGE_VALUE),
     motivation: clampPerformanceGauge(player.motivation, DEFAULT_GAUGE_VALUE),
+    injuryStatus: player.injuryStatus ?? 'healthy',
   };
 }
 

--- a/src/services/academy.ts
+++ b/src/services/academy.ts
@@ -170,6 +170,7 @@ function candidateToPlayer(id: string, c: CandidatePlayer): Player {
     squadRole: 'reserve',
     condition: parseFloat((0.65 + Math.random() * 0.3).toFixed(3)),
     motivation: parseFloat((0.6 + Math.random() * 0.35).toFixed(3)),
+    injuryStatus: 'healthy',
   };
 }
 

--- a/src/services/legends.ts
+++ b/src/services/legends.ts
@@ -38,6 +38,7 @@ function legendToPlayer(id: string, legend: LegendPlayer): Player {
     squadRole: 'reserve',
     condition: 0.96,
     motivation: 0.98,
+    injuryStatus: 'healthy',
     avatar: legend.image,
     uniqueId: `legend-${legend.id}`,
   };

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -59,6 +59,7 @@ const generatePlayer = (
     squadRole: 'reserve',
     condition: randomGauge(),
     motivation: randomGauge(),
+    injuryStatus: 'healthy',
   };
 };
 
@@ -263,7 +264,7 @@ export const addPlayerToTeam = async (userId: string, player: Player) => {
   if (!team) return;
   const updatedPlayers = [
     ...team.players,
-    { ...player, squadRole: 'reserve' as const },
+    { ...player, injuryStatus: player.injuryStatus ?? 'healthy', squadRole: 'reserve' as const },
   ];
   await setDoc(doc(db, 'teams', userId), { players: updatedPlayers }, { merge: true });
   return updatedPlayers;

--- a/src/services/youth.test.ts
+++ b/src/services/youth.test.ts
@@ -60,6 +60,9 @@ const player: Player = {
   height: 180,
   weight: 70,
   squadRole: 'youth',
+  condition: 0.7,
+  motivation: 0.7,
+  injuryStatus: 'healthy',
 };
 
 beforeEach(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,10 @@ export type Position =
   | 'RW'
   | 'ST';
 
+export type InjuryStatus = 'healthy' | 'injured';
+
+export type KitType = 'energy' | 'morale' | 'health';
+
 export interface Player {
   id: string;
   name: string;
@@ -42,6 +46,7 @@ export interface Player {
   weight: number;
   condition: number;
   motivation: number;
+  injuryStatus?: InjuryStatus;
   squadRole: SquadRole | 'youth';
   avatar?: string;
   uniqueId?: string;


### PR DESCRIPTION
## Summary
- add an inventory context that tracks kit balances, persists them per user, and applies stat boosts or healing to players when a kit is used
- surface the new kits in the top bar with purchase options and a dialog for choosing a player to receive the boost
- extend the player model with an injury status, update generation/defaults, and reflect the state in power calculations and player-facing UI

## Testing
- npm run lint *(fails: pre-existing lint errors across legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68deb76f4044832ab800902c9d02f56e