### PR TITLE
feat: enable player rename and contract management

### DIFF
--- a/src/components/ui/player-card.tsx
+++ b/src/components/ui/player-card.tsx
@@ -25,6 +25,8 @@ interface PlayerCardProps {
   onPromoteToTeam?: () => void;
   onListForTransfer?: () => void;
   onReleasePlayer?: () => void;
+  onRenamePlayer?: () => void;
+  onFirePlayer?: () => void;
   showActions?: boolean;
   compact?: boolean;
   defaultCollapsed?: boolean;
@@ -56,6 +58,8 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
   onPromoteToTeam,
   onListForTransfer,
   onReleasePlayer,
+  onRenamePlayer,
+  onFirePlayer,
   showActions = true,
   compact = false,
   defaultCollapsed = false,
@@ -116,6 +120,24 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
 
   const condition = clampPerformanceGauge(player.condition);
   const motivation = clampPerformanceGauge(player.motivation);
+  const contractExpiresAt = player.contract?.expiresAt
+    ? new Date(player.contract.expiresAt)
+    : null;
+  const contractStatus = player.contract?.status ?? 'active';
+  const isContractExpired =
+    contractExpiresAt !== null && contractExpiresAt.getTime() <= Date.now();
+  const contractBadgeVariant =
+    contractStatus === 'released'
+      ? 'secondary'
+      : isContractExpired
+        ? 'destructive'
+        : 'outline';
+  const contractLabel =
+    contractStatus === 'released'
+      ? 'Serbest'
+      : contractExpiresAt
+        ? `Söz.: ${contractExpiresAt.toLocaleDateString('tr-TR')}`
+        : 'Söz.: -';
   const power = useMemo(
     () =>
       calculatePowerIndex({
@@ -197,6 +219,14 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
                 <Badge variant="secondary" className={cn('text-xs', compact && 'text-[10px]')}>
                   {player.age} yaş
                 </Badge>
+                {player.contract && (
+                  <Badge
+                    variant={contractBadgeVariant}
+                    className={cn('text-xs', compact && 'text-[10px]')}
+                  >
+                    {contractLabel}
+                  </Badge>
+                )}
                 {player.injuryStatus === 'injured' && (
                   <Badge variant="destructive" className={cn('text-xs', compact && 'text-[10px]')}>
                     Sakat
@@ -248,12 +278,22 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({
                   {player.squadRole !== 'reserve' && onMoveToReserve && (
                     <DropdownMenuItem onClick={onMoveToReserve}>Rezerve Al</DropdownMenuItem>
                   )}
-                  {(onListForTransfer || onReleasePlayer) && <DropdownMenuSeparator />}
+                  {(onRenamePlayer || onListForTransfer || onReleasePlayer || onFirePlayer) && (
+                    <DropdownMenuSeparator />
+                  )}
+                  {onRenamePlayer && (
+                    <DropdownMenuItem onClick={onRenamePlayer}>İsim Özelleştir</DropdownMenuItem>
+                  )}
                   {onListForTransfer && (
                     <DropdownMenuItem onClick={onListForTransfer}>Oyuncuyu Pazara Koy</DropdownMenuItem>
                   )}
                   {onReleasePlayer && (
                     <DropdownMenuItem onClick={onReleasePlayer}>Serbest Bırak</DropdownMenuItem>
+                  )}
+                  {onFirePlayer && (
+                    <DropdownMenuItem className="text-destructive" onClick={onFirePlayer}>
+                      Oyuncuyu Kov
+                    </DropdownMenuItem>
                   )}
                   {player.squadRole === 'youth' && onPromoteToTeam && (
                     <DropdownMenuItem onClick={onPromoteToTeam}>Takıma Al</DropdownMenuItem>

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -8,6 +8,28 @@ import { formations } from '@/lib/formations';
 
 const positions: Player['position'][] = ['GK','CB','LB','RB','CM','LM','RM','CAM','LW','RW','ST'];
 
+const CONTRACT_MIN_YEARS = 2;
+const CONTRACT_MAX_YEARS = 4;
+
+const createInitialContract = (): NonNullable<Player['contract']> => {
+  const current = new Date();
+  const years = Math.floor(Math.random() * (CONTRACT_MAX_YEARS - CONTRACT_MIN_YEARS + 1)) + CONTRACT_MIN_YEARS;
+  const base = new Date(current);
+  base.setFullYear(base.getFullYear() + years);
+  return {
+    expiresAt: base.toISOString(),
+    status: 'active',
+    salary: Math.floor(1500 + Math.random() * 3500),
+    extensions: 0,
+  };
+};
+
+const createInitialRenameState = (): NonNullable<Player['rename']> => ({
+  adAvailableAt: new Date(0).toISOString(),
+  lastMethod: undefined,
+  lastUpdatedAt: undefined,
+});
+
 const clampPercentage = (value: unknown): number => {
   const numeric = typeof value === 'number' ? value : Number(value);
   if (!Number.isFinite(numeric)) {
@@ -60,6 +82,8 @@ const generatePlayer = (
     condition: randomGauge(),
     motivation: randomGauge(),
     injuryStatus: 'healthy',
+    contract: createInitialContract(),
+    rename: createInitialRenameState(),
   };
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,17 @@ export interface Player {
     active: boolean;
     listingId?: string | null;
   } | null;
+  contract?: {
+    expiresAt: string;
+    status?: 'active' | 'expired' | 'released';
+    salary?: number;
+    extensions?: number;
+  } | null;
+  rename?: {
+    lastUpdatedAt?: string;
+    lastMethod?: 'ad' | 'purchase';
+    adAvailableAt?: string;
+  } | null;
 }
 
 export type CustomFormationLayout = Record<


### PR DESCRIPTION
## Summary
- add contract and rename metadata to players and seed data to support roster actions
- extend the team planning workflow with dialogs and handlers for renaming players, resolving expired contracts, and firing players
- surface contract status and management actions in player cards for quick access

## Testing
- pnpm lint *(fails: existing lint issues across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dec5c26980832a9534b0a4fa232378