### PR TITLE
Handle offline training completion and notifications

### DIFF
--- a/src/lib/trainingSession.ts
+++ b/src/lib/trainingSession.ts
@@ -1,0 +1,84 @@
+import { calculateOverall } from '@/lib/player';
+import type { Player, Training } from '@/types';
+
+export type TrainingSimulationRecord = {
+  playerId: string;
+  playerName: string;
+  trainingId: string;
+  trainingName: string;
+  result: 'success' | 'average' | 'fail';
+  gain: number;
+};
+
+export type TrainingSimulationResult = {
+  updatedPlayers: Player[];
+  records: TrainingSimulationRecord[];
+};
+
+export function runTrainingSimulation(
+  players: Player[],
+  trainings: Training[],
+  rng: () => number = Math.random,
+): TrainingSimulationResult {
+  const records: TrainingSimulationRecord[] = [];
+  const updatedPlayers: Player[] = [];
+
+  for (const player of players) {
+    let snapshot: Player = {
+      ...player,
+      attributes: { ...player.attributes },
+    };
+
+    for (const training of trainings) {
+      const attributeKey = training.type;
+      const currentValue = snapshot.attributes[attributeKey];
+      let gain = 0;
+      let result: 'success' | 'average' | 'fail' = 'fail';
+
+      if (currentValue < 1) {
+        const improvement = 0.005 + rng() * 0.03;
+        const successRoll = rng() * 100;
+
+        if (successRoll > 75) {
+          gain = improvement;
+          result = 'success';
+        } else if (successRoll > 45) {
+          gain = improvement * 0.5;
+          result = 'average';
+        } else {
+          result = 'fail';
+        }
+
+        if (gain > 0) {
+          const newValue = Math.min(currentValue + gain, 1);
+          const newAttributes = {
+            ...snapshot.attributes,
+            [attributeKey]: newValue,
+          } as Player['attributes'];
+
+          snapshot = {
+            ...snapshot,
+            attributes: newAttributes,
+            overall: Math.min(
+              calculateOverall(snapshot.position, newAttributes),
+              snapshot.potential,
+            ),
+          };
+        }
+      }
+
+      records.push({
+        playerId: snapshot.id,
+        playerName: snapshot.name,
+        trainingId: training.id,
+        trainingName: training.name,
+        result,
+        gain,
+      });
+    }
+
+    updatedPlayers.push(snapshot);
+  }
+
+  return { updatedPlayers, records };
+}

--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -25,7 +25,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { getMyLeagueId, listLeagueStandings, getFixturesForTeam } from '@/services/leagues';
 import { getTeam } from '@/services/team';
-import { getUnviewedTrainingCount } from '@/services/training';
+import { finalizeExpiredTrainingSession, getUnviewedTrainingCount } from '@/services/training';
 import { getYouthCandidates } from '@/services/youth';
 
 const menuItems = [
@@ -126,6 +126,12 @@ export default function MainMenu() {
         setHasUnseenTrainingResults(false);
         setHasYouthCandidates(false);
         return;
+      }
+
+      try {
+        await finalizeExpiredTrainingSession(user.id);
+      } catch (err) {
+        console.warn('[MainMenu] finalize training failed', err);
       }
 
       try {


### PR DESCRIPTION
## Summary
- extract a reusable training simulation helper so training results can be calculated consistently
- auto-complete expired training sessions, persist results, and clear active state even when the app was closed
- trigger main menu notifications for unseen training outcomes while keeping the existing youth academy alert

## Testing
- npm run lint *(fails: repository already contains many pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68decaeae52c832a8130d228565e498d