### PR TITLE
Fix rename fallback typing

### DIFF
--- a/src/pages/TeamPlanning.tsx
+++ b/src/pages/TeamPlanning.tsx
@@ -213,11 +213,21 @@ function normalizePlayer(player: Player): Player {
     extensions: player.contract?.extensions ?? 0,
   });
 
-  const fallbackRename = (): NonNullable<Player['rename']> => ({
-    adAvailableAt: new Date(0).toISOString(),
-    lastMethod: player.rename?.lastMethod,
-    lastUpdatedAt: player.rename?.lastUpdatedAt,
-  });
+  const fallbackRename = (): NonNullable<Player['rename']> => {
+    const details: NonNullable<Player['rename']> = {
+      adAvailableAt: new Date(0).toISOString(),
+    };
+
+    if (player.rename?.lastUpdatedAt) {
+      details.lastUpdatedAt = player.rename.lastUpdatedAt;
+    }
+
+    if (player.rename?.lastMethod === 'ad' || player.rename?.lastMethod === 'purchase') {
+      details.lastMethod = player.rename.lastMethod;
+    }
+
+    return details;
+  };
 
   return {
     ...player,


### PR DESCRIPTION
## Summary
- update the team planning rename fallback helper to only retain valid rename metadata

## Testing
- pnpm lint *(fails: pre-existing lint errors throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68decff241d4832ab7ed6e2b440b28bd