### PR TITLE
Improve registration reliability and messaging

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -16,6 +16,30 @@ import {
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { Loader2, Chrome, Apple } from 'lucide-react';
+import { FirebaseError } from 'firebase/app';
+
+const getRegisterErrorMessage = (error: unknown): string => {
+  if (error instanceof FirebaseError) {
+    const map: Record<string, string> = {
+      'auth/email-already-in-use': 'Bu e-posta adresi zaten kullanımda.',
+      'auth/invalid-email': 'Geçerli bir e-posta adresi girin.',
+      'auth/weak-password': 'Şifreniz en az 6 karakter olmalı.',
+      'auth/operation-not-allowed': 'Kayıt işlemi devre dışı. Lütfen daha sonra tekrar deneyin.',
+      'permission-denied': 'Takım oluşturulamadı. Lütfen tekrar deneyin.',
+    };
+    const friendly = map[error.code];
+    if (friendly) {
+      return friendly;
+    }
+    if (error.message) {
+      return error.message;
+    }
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return 'Kayıt başarısız';
+};
 
 export default function Auth() {
   const {
@@ -61,7 +85,8 @@ export default function Auth() {
       await register(registerForm.email, registerForm.password, trimmedTeamName);
       toast.success('Hesap başarıyla oluşturuldu!');
     } catch (error) {
-      toast.error('Kayıt başarısız');
+      console.error('register error:', error);
+      toast.error(getRegisterErrorMessage(error));
     }
   };
 


### PR DESCRIPTION
## Summary
- wait for Firebase auth state to settle and retry initial team creation with token refresh to avoid spurious sign-up failures
- keep the user state in sync immediately after registration while logging non-blocking assignment issues
- show descriptive error messages on the registration form based on Firebase error codes instead of a generic failure toast

## Testing
- npm run lint *(fails: pre-existing lint errors across the repo, including many `any` usages and empty blocks outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68decdeb2640832aacdfa2782141725f