### PR TITLE
Fix initial team creation when auth state is not ready

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -65,7 +65,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           connectedAccounts: { google: false, apple: false },
         });
         if (!team) {
-          await createInitialTeam(firebaseUser.uid, teamName, username);
+          await createInitialTeam(firebaseUser.uid, teamName, username, {
+            authUser: firebaseUser,
+          });
           // Slot tabanlı: sıradaki ligde rastgele bir BOT'un yerine geç
           await requestAssign(firebaseUser.uid);
         } else if (!(team as any)?.leagueId) {
@@ -155,7 +157,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             const MAX_ATTEMPTS = 3;
             for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
               try {
-                await createInitialTeam(user.uid, teamName, managerName);
+                await createInitialTeam(user.uid, teamName, managerName, {
+                  authUser: user,
+                });
                 return;
               } catch (createError) {
                 const errorMessage = createError instanceof Error ? createError.message : '';
@@ -257,7 +261,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       await updateProfile(firebaseUser, { displayName: trimmedName });
 
       if (!team) {
-        await createInitialTeam(firebaseUser.uid, trimmedName, managerName);
+        await createInitialTeam(firebaseUser.uid, trimmedName, managerName, {
+          authUser: firebaseUser,
+        });
         void requestAssign(firebaseUser.uid).catch((err) => {
           console.warn('[AuthContext] League assignment failed after social registration', err);
         });

--- a/src/pages/TeamPlanning.tsx
+++ b/src/pages/TeamPlanning.tsx
@@ -7,6 +7,7 @@ import { PlayerCard } from '@/components/ui/player-card';
 import { PerformanceGauge, clampPerformanceGauge } from '@/components/ui/performance-gauge';
 import { Player, CustomFormationMap } from '@/types';
 import { getTeam, saveTeamPlayers, createInitialTeam } from '@/services/team';
+import { auth } from '@/services/firebase';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDiamonds } from '@/contexts/DiamondContext';
 import { Search, Save, Eye, ArrowUp } from 'lucide-react';
@@ -1086,7 +1087,9 @@ export default function TeamPlanning() {
     (async () => {
       let team = await getTeam(user.id);
       if (!team) {
-        team = await createInitialTeam(user.id, user.teamName, user.teamName);
+        team = await createInitialTeam(user.id, user.teamName, user.teamName, {
+          authUser: auth.currentUser,
+        });
       }
 
       const normalized = normalizePlayers(team.players);


### PR DESCRIPTION
## Summary
- retry initial team creation with a supplied Firebase user when Firestore denies the first write
- pass the freshly signed-in Firebase user to team creation during registration and social sign-ups
- provide the same fallback when recreating a missing team from the planning screen

## Testing
- `npm run lint` *(fails: repository has pre-existing lint errors across many files)*

------
https://chatgpt.com/codex/tasks/task_e_68ded2678098832a8ab29843989c2b61