### PR TITLE
Refresh youth academy interface with modern theme

### DIFF
--- a/src/features/youth/CooldownPanel.tsx
+++ b/src/features/youth/CooldownPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
 import {
   YOUTH_AD_REDUCTION_MS,
   YOUTH_COOLDOWN_MS,
@@ -14,6 +15,7 @@ interface Props {
   canReset: boolean;
   onWatchAd: () => void;
   canWatchAd: boolean;
+  className?: string;
 }
 
 const CooldownPanel: React.FC<Props> = ({
@@ -22,6 +24,7 @@ const CooldownPanel: React.FC<Props> = ({
   canReset,
   onWatchAd,
   canWatchAd,
+  className,
 }) => {
   const [remaining, setRemaining] = useState(0);
 
@@ -54,15 +57,20 @@ const CooldownPanel: React.FC<Props> = ({
   const canGenerate = remaining === 0;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Oyuncu Üretimi</CardTitle>
+    <Card
+      className={cn(
+        'border-white/10 bg-slate-900/80 text-slate-100 shadow-xl backdrop-blur',
+        className,
+      )}
+    >
+      <CardHeader className="pb-4">
+        <CardTitle className="text-xl font-semibold text-white">Oyuncu Üretimi</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-2">
-        <Progress value={progress} className="h-2" />
-        <div className="space-y-3 text-sm">
-          <div className="flex items-center justify-between">
-            <span>
+      <CardContent className="space-y-4 text-sm text-slate-200">
+        <Progress value={progress} className="h-2 bg-white/10" />
+        <div className="space-y-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <span className="font-medium text-white">
               Sonraki üretim: {hours}:{minutes}:{seconds}
             </span>
             <div className="flex flex-wrap items-center justify-end gap-2">
@@ -72,6 +80,7 @@ const CooldownPanel: React.FC<Props> = ({
                 size="sm"
                 variant="outline"
                 data-testid="youth-watch-ad"
+                className="border-white/20 bg-transparent text-cyan-100 hover:border-cyan-400/60 hover:bg-cyan-500/20 hover:text-white"
               >
                 Reklam İzle (-12 saat)
               </Button>
@@ -81,12 +90,13 @@ const CooldownPanel: React.FC<Props> = ({
                 size="sm"
                 variant="secondary"
                 data-testid="youth-reset"
+                className="border border-transparent bg-gradient-to-r from-emerald-500 to-cyan-500 text-slate-950 shadow-lg shadow-emerald-500/20 hover:from-emerald-400 hover:to-cyan-400"
               >
                 Hemen Al (💎{YOUTH_RESET_DIAMOND_COST})
               </Button>
             </div>
           </div>
-          <p className="text-muted-foreground">
+          <p className="leading-relaxed text-slate-300">
             Altyapı oyuncuları haftada bir gelir. Reklam izleyerek bekleme süresini{' '}
             {(YOUTH_AD_REDUCTION_MS / 3600000).toFixed(0)} saat kısaltabilir veya elmas
             kullanarak hemen yeni oyuncu alabilirsin.

--- a/src/features/youth/YouthCandidateCard.tsx
+++ b/src/features/youth/YouthCandidateCard.tsx
@@ -43,27 +43,30 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
   return (
     <Card
       data-testid={`youth-candidate-${candidate.id}`}
-      className="p-4 hover:shadow-md transition-all transform hover:scale-105 group"
+      className="group relative overflow-hidden border border-white/10 bg-slate-900/70 p-5 text-slate-100 shadow-lg backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-xl"
     >
-      <div className="flex items-start gap-3">
+      <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+        <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/10 via-transparent to-emerald-500/20" />
+      </div>
+      <div className="relative flex items-start gap-4">
         <div className="relative">
-          <div className="w-12 h-12 bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-800 rounded-full flex items-center justify-center text-lg font-semibold">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-500 to-emerald-500 text-lg font-semibold text-white shadow-lg shadow-cyan-500/20">
             {initials}
           </div>
-          <div className="absolute -bottom-1 -right-1 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold text-white bg-gray-500">
+          <div className="absolute -bottom-1 -right-1 flex h-7 w-7 items-center justify-center rounded-full border border-white/20 bg-slate-950/80 text-[11px] font-bold text-cyan-100 shadow-md shadow-cyan-500/20">
             {player.position}
           </div>
         </div>
         <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between mb-2">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div>
-              <h3 className="font-semibold text-sm truncate">{player.name}</h3>
-              <div className="flex items-center gap-2 mt-1">
-                <Badge variant="secondary" className="text-xs">
+              <h3 className="truncate text-base font-semibold tracking-tight">{player.name}</h3>
+              <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                <Badge variant="secondary" className="border-white/20 bg-white/10 text-white backdrop-blur">
                   {player.age} yaş
                 </Badge>
-                <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                  <TrendingUp className="w-3 h-3" />
+                <div className="flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-1 text-[11px] font-medium text-cyan-100 shadow-inner shadow-cyan-500/10">
+                  <TrendingUp className="h-3 w-3" />
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="font-semibold">
@@ -75,21 +78,26 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                     </TooltipContent>
                   </Tooltip>
                 </div>
-                <div className="flex gap-1">
+                <div className="flex flex-wrap gap-1">
                   {player.roles.map((role) => (
-                    <Badge key={role} variant="outline" className="text-xs">
+                    <Badge
+                      key={role}
+                      variant="outline"
+                      className="border-white/20 bg-transparent text-cyan-100"
+                    >
                       {role}
                     </Badge>
                   ))}
                 </div>
               </div>
             </div>
-            <div className="flex gap-1">
+            <div className="flex flex-wrap gap-2">
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => onAccept(candidate.id)}
                 data-testid={`youth-accept-${candidate.id}`}
+                className="rounded-full border border-transparent bg-white/5 px-4 text-xs font-semibold text-cyan-100 shadow-sm transition hover:border-cyan-400/60 hover:bg-cyan-500/20 hover:text-white"
               >
                 Takıma Al
               </Button>
@@ -98,6 +106,7 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                 size="sm"
                 onClick={() => onRelease(candidate.id)}
                 data-testid={`youth-release-${candidate.id}`}
+                className="rounded-full border border-transparent bg-white/5 px-4 text-xs font-semibold text-slate-200 shadow-sm transition hover:border-rose-500/60 hover:bg-rose-500/20 hover:text-white"
               >
                 Serbest Bırak
               </Button>
@@ -105,14 +114,19 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
           </div>
           <div className="space-y-1">
             {basicStats.map(([label, value]) => (
-              <StatBar key={label} label={label} value={value} />
+              <StatBar key={label} label={label} value={value} className="text-slate-200" />
             ))}
-            <div className="hidden group-hover:block space-y-1 mt-2">
+            <div className="mt-3 hidden space-y-1 text-xs text-slate-300 group-hover:block">
               {extraStats.map(([label, value]) => (
-                <StatBar key={label} label={label} value={value} />
+                <StatBar key={label} label={label} value={value} className="text-slate-200" />
               ))}
-              <div className="text-xs text-muted-foreground mt-2">
-                Boy: {player.height} cm · Kilo: {player.weight} kg
+              <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-wide text-slate-300/90">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">
+                  Boy: {player.height} cm
+                </span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">
+                  Kilo: {player.weight} kg
+                </span>
               </div>
             </div>
           </div>

--- a/src/features/youth/YouthList.tsx
+++ b/src/features/youth/YouthList.tsx
@@ -1,22 +1,31 @@
 import YouthCandidateCard from './YouthCandidateCard';
 import { YouthCandidate } from '@/services/youth';
+import { cn } from '@/lib/utils';
 
 interface Props {
   candidates: YouthCandidate[];
   onAccept: (id: string) => void;
   onRelease: (id: string) => void;
+  className?: string;
+  emptyStateClassName?: string;
 }
 
-const YouthList: React.FC<Props> = ({ candidates, onAccept, onRelease }) => {
+const YouthList: React.FC<Props> = ({
+  candidates,
+  onAccept,
+  onRelease,
+  className,
+  emptyStateClassName,
+}) => {
   if (candidates.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">
+      <p className={cn('text-sm text-muted-foreground', emptyStateClassName)}>
         Henüz altyapı oyuncusu yok. Yeni aday üret.
       </p>
     );
   }
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <div className={cn('grid gap-4 md:grid-cols-2 lg:grid-cols-3', className)}>
       {candidates.map((c) => (
         <YouthCandidateCard
           key={c.id}

--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -20,10 +20,13 @@ import { db } from '@/services/firebase';
 import { generateRandomName } from '@/lib/names';
 import { calculateOverall, getRoles } from '@/lib/player';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import YouthList from './YouthList';
 import CooldownPanel from './CooldownPanel';
 import type { Player } from '@/types';
 import { BackButton } from '@/components/ui/back-button';
+import { Sparkles, Clock, Users, Gauge, ArrowRight } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 const positions: Player['position'][] = ['GK','CB','LB','RB','CM','LM','RM','CAM','LW','RW','ST'];
 const randomAttr = () => parseFloat(Math.random().toFixed(3));
@@ -62,6 +65,31 @@ const generatePlayer = (): Player => {
     squadRole: 'youth',
   };
 };
+
+interface StatCardProps {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  helper: string;
+}
+
+const StatCard: React.FC<StatCardProps> = ({ icon: Icon, label, value, helper }) => (
+  <div className="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-5 shadow-lg backdrop-blur transition-transform duration-300 hover:-translate-y-1 hover:border-cyan-400/40">
+    <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+      <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/10 via-transparent to-emerald-500/20" />
+    </div>
+    <div className="relative flex items-start gap-4">
+      <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900/70 text-cyan-200 shadow-inner shadow-cyan-500/20">
+        <Icon className="h-5 w-5" />
+      </div>
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/70">{label}</p>
+        <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
+        <p className="mt-1 text-sm text-slate-300">{helper}</p>
+      </div>
+    </div>
+  </div>
+);
 
 const YouthPage = () => {
   const { user } = useAuth();
@@ -176,29 +204,152 @@ const YouthPage = () => {
     return <div className="p-4">Giriş yapmalısın</div>;
   }
 
+  const candidateCount = candidates.length;
+  const averageOverall =
+    candidateCount === 0
+      ? 0
+      : Math.round(
+          (candidates.reduce((acc, curr) => acc + curr.player.overall, 0) / candidateCount) *
+            100,
+        );
+  const topPotential =
+    candidateCount === 0 ? 0 : Math.round(Math.max(...candidates.map((c) => c.player.potential)) * 100);
+  const heroMessage =
+    candidateCount > 0
+      ? `Kadron için ${candidateCount} umut vadeden oyuncu seni bekliyor. En yüksek potansiyel ${topPotential}.`
+      : 'İlk altyapı yeteneklerini keşfetmek için hemen üretim yap.';
+  const nextGenerateTime = canGenerate
+    ? 'Hazır'
+    : nextGenerateAt
+      ? nextGenerateAt.toLocaleTimeString('tr-TR', { hour: '2-digit', minute: '2-digit' })
+      : '—';
+  const nextGenerateHelper = canGenerate
+    ? 'Yeni aday hemen üretilebilir'
+    : 'Planlanan üretim saati';
+
+  const stats: StatCardProps[] = [
+    {
+      icon: Users,
+      label: 'Aday Havuzu',
+      value: candidateCount.toString(),
+      helper: candidateCount > 0 ? 'Seçime hazır genç yetenek' : 'Henüz aday bulunmuyor',
+    },
+    {
+      icon: Gauge,
+      label: 'Ortalama Genel',
+      value: candidateCount > 0 ? averageOverall.toString() : '—',
+      helper: 'Performans puanı (100 üzerinden)',
+    },
+    {
+      icon: Sparkles,
+      label: 'En Yüksek Potansiyel',
+      value: candidateCount > 0 ? topPotential.toString() : '—',
+      helper:
+        candidateCount > 0 ? 'Scout ekibinin gördüğü tavan' : 'Aday üretildiğinde görüntülenir',
+    },
+    {
+      icon: Clock,
+      label: 'Yeni Üretim',
+      value: nextGenerateTime,
+      helper: nextGenerateHelper,
+    },
+  ];
+
   return (
-    <div className="p-4 space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <BackButton />
-          <h1 className="text-2xl font-bold">Altyapı</h1>
+    <div className="p-4">
+      <div className="relative mx-auto max-w-6xl overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-6 py-8 text-slate-100 shadow-2xl">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),_transparent_60%)]" />
+        <div className="pointer-events-none absolute -left-24 bottom-0 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
+        <div className="pointer-events-none absolute right-[-10%] top-[-20%] h-72 w-72 rounded-full bg-cyan-500/25 blur-3xl" />
+        <div className="relative space-y-10">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center gap-3">
+                <BackButton />
+                <div>
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-cyan-200">
+                    <Sparkles className="h-3.5 w-3.5" />
+                    altyapı yönetimi
+                  </span>
+                  <h1 className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">Altyapı Merkezi</h1>
+                  <p className="mt-3 max-w-2xl text-sm text-slate-300 sm:text-base">{heroMessage}</p>
+                </div>
+              </div>
+            </div>
+            <Button
+              onClick={handleGenerate}
+              disabled={!canGenerate}
+              data-testid="youth-generate"
+              className="group relative overflow-hidden rounded-full border-0 bg-gradient-to-r from-cyan-500 via-emerald-500 to-teal-500 px-6 py-3 text-base font-semibold text-slate-950 shadow-lg shadow-cyan-500/30 transition hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="relative flex items-center gap-2">
+                <Sparkles className="h-5 w-5 transition-transform group-hover:rotate-6" />
+                Oyuncu Üret
+              </span>
+            </Button>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {stats.map((stat) => (
+              <StatCard key={stat.label} {...stat} />
+            ))}
+          </div>
+          <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+            <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold text-white">Oyuncu Havuzu</h2>
+                  <p className="mt-1 text-sm text-slate-300">
+                    Gelişime hazır genç yetenekleri filtrele ve doğru zamanda A takıma yükselt.
+                  </p>
+                </div>
+                {candidateCount > 0 && (
+                  <Badge
+                    variant="outline"
+                    className="w-fit border-white/20 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-cyan-200"
+                  >
+                    {candidateCount} Aday
+                  </Badge>
+                )}
+              </div>
+              <div className="mt-6">
+                <YouthList
+                  candidates={candidates}
+                  onAccept={handleAccept}
+                  onRelease={handleRelease}
+                  className="2xl:grid-cols-3"
+                  emptyStateClassName="text-slate-300"
+                />
+              </div>
+            </section>
+            <aside className="space-y-6">
+              <CooldownPanel
+                nextGenerateAt={nextGenerateAt}
+                onReset={handleReset}
+                canReset={balance >= YOUTH_RESET_DIAMOND_COST && !canGenerate}
+                onWatchAd={handleWatchAd}
+                canWatchAd={!canGenerate}
+              />
+              <div className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur">
+                <h3 className="text-lg font-semibold text-white">Scout Notları</h3>
+                <ul className="mt-4 space-y-3 text-sm text-slate-300">
+                  <li className="flex items-start gap-2">
+                    <ArrowRight className="mt-0.5 h-4 w-4 text-cyan-300" />
+                    <span>Yüksek potansiyelli oyuncuları hazırlık kampına erken dahil ederek gelişim patlaması yakala.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <ArrowRight className="mt-0.5 h-4 w-4 text-cyan-300" />
+                    <span>Reklam izleyerek bekleme süresini kısalt ve transfer dönemlerinde altyapını sıcak tut.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <ArrowRight className="mt-0.5 h-4 w-4 text-cyan-300" />
+                    <span>Elmasla beklemeyi sıfırlamak, kritik maçlardan önce kadroyu tazelemek için güçlü bir hamle.</span>
+                  </li>
+                </ul>
+              </div>
+            </aside>
+          </div>
         </div>
-        <Button onClick={handleGenerate} disabled={!canGenerate} data-testid="youth-generate">
-          Oyuncu Üret
-        </Button>
       </div>
-      <CooldownPanel
-        nextGenerateAt={nextGenerateAt}
-        onReset={handleReset}
-        canReset={balance >= YOUTH_RESET_DIAMOND_COST && !canGenerate}
-        onWatchAd={handleWatchAd}
-        canWatchAd={!canGenerate}
-      />
-      <YouthList
-        candidates={candidates}
-        onAccept={handleAccept}
-        onRelease={handleRelease}
-      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- restyle the youth academy page with a gradient hero, stat overview cards, and scout tips for a more modern feel
- refresh youth candidate cards and cooldown panel with glassmorphism-inspired accents and interactive hover states
- make the youth list and cooldown panel support style overrides for better visual integration

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e187b9aea4832abaedee9d2c59179e