### PR TITLE
Widen youth candidate cards for better button visibility

### DIFF
--- a/src/features/youth/YouthList.tsx
+++ b/src/features/youth/YouthList.tsx
@@ -25,7 +25,7 @@ const YouthList: React.FC<Props> = ({
     );
   }
   return (
-    <div className={cn('grid gap-4 md:grid-cols-2 lg:grid-cols-3', className)}>
+    <div className={cn('grid gap-4 md:grid-cols-2 xl:grid-cols-3', className)}>
       {candidates.map((c) => (
         <YouthCandidateCard
           key={c.id}


### PR DESCRIPTION
## Summary
- adjust the youth candidate grid layout to keep cards wider at large breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18caaabc0832ab27facfe6164a4f4