### PR TITLE
Improve youth page layout and card sizing

### DIFF
--- a/src/features/youth/YouthCandidateCard.tsx
+++ b/src/features/youth/YouthCandidateCard.tsx
@@ -43,13 +43,13 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
   return (
     <Card
       data-testid={`youth-candidate-${candidate.id}`}
-      className="group relative overflow-hidden border border-white/10 bg-slate-900/70 p-5 text-slate-100 shadow-lg backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-xl"
+      className="group relative flex h-full flex-col overflow-hidden border border-white/10 bg-slate-900/70 p-5 text-slate-100 shadow-lg backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-xl"
     >
       <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
         <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/10 via-transparent to-emerald-500/20" />
       </div>
-      <div className="relative flex items-start gap-4">
-        <div className="relative">
+      <div className="relative flex flex-1 flex-col gap-4 sm:flex-row sm:items-start">
+        <div className="relative shrink-0">
           <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-500 to-emerald-500 text-lg font-semibold text-white shadow-lg shadow-cyan-500/20">
             {initials}
           </div>
@@ -57,7 +57,7 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
             {player.position}
           </div>
         </div>
-        <div className="flex-1 min-w-0">
+        <div className="min-w-0 flex flex-1 flex-col">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div>
               <h3 className="truncate text-base font-semibold tracking-tight">{player.name}</h3>
@@ -112,10 +112,12 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
               </Button>
             </div>
           </div>
-          <div className="space-y-1">
-            {basicStats.map(([label, value]) => (
-              <StatBar key={label} label={label} value={value} className="text-slate-200" />
-            ))}
+          <div className="mt-4 flex flex-1 flex-col justify-between">
+            <div className="space-y-1">
+              {basicStats.map(([label, value]) => (
+                <StatBar key={label} label={label} value={value} className="text-slate-200" />
+              ))}
+            </div>
             <div className="mt-3 hidden space-y-1 text-xs text-slate-300 group-hover:block">
               {extraStats.map(([label, value]) => (
                 <StatBar key={label} label={label} value={value} className="text-slate-200" />

--- a/src/features/youth/YouthList.tsx
+++ b/src/features/youth/YouthList.tsx
@@ -25,7 +25,7 @@ const YouthList: React.FC<Props> = ({
     );
   }
   return (
-    <div className={cn('grid gap-4 md:grid-cols-2 xl:grid-cols-3', className)}>
+    <div className={cn('grid auto-rows-fr gap-4 md:grid-cols-2 xl:grid-cols-3', className)}>
       {candidates.map((c) => (
         <YouthCandidateCard
           key={c.id}

--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -256,12 +256,25 @@ const YouthPage = () => {
   ];
 
   return (
-    <div className="p-4">
-      <div className="relative mx-auto max-w-6xl overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-6 py-8 text-slate-100 shadow-2xl">
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),_transparent_60%)]" />
-        <div className="pointer-events-none absolute -left-24 bottom-0 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
-        <div className="pointer-events-none absolute right-[-10%] top-[-20%] h-72 w-72 rounded-full bg-cyan-500/25 blur-3xl" />
-        <div className="relative space-y-10">
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_65%)]"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute -left-32 top-24 h-96 w-96 rounded-full bg-emerald-500/15 blur-3xl"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute right-[-18%] bottom-[-10%] h-[28rem] w-[28rem] rounded-full bg-cyan-500/15 blur-[140px]"
+        aria-hidden
+      />
+      <div className="relative z-10 px-4 py-10 sm:px-6 lg:px-8">
+        <div className="relative mx-auto max-w-6xl rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-6 py-8 shadow-2xl">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),_transparent_60%)]" />
+          <div className="pointer-events-none absolute -left-24 bottom-0 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
+          <div className="pointer-events-none absolute right-[-10%] top-[-20%] h-72 w-72 rounded-full bg-cyan-500/25 blur-3xl" />
+          <div className="relative space-y-10">
           <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
             <div className="flex flex-col gap-4">
               <div className="flex items-center gap-3">
@@ -347,6 +360,7 @@ const YouthPage = () => {
                 </ul>
               </div>
             </aside>
+          </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- extend the Youth page shell with a full-height gradient background to match the rest of the app
- tweak youth candidate cards so they stretch to full height and keep action buttons fully visible
- update the youth list grid to create evenly sized card columns

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e18dd25144832a9f6932a8006f4b0b