### PR TITLE
Fix youth candidate card layout spacing

### DIFF
--- a/src/features/youth/YouthList.tsx
+++ b/src/features/youth/YouthList.tsx
@@ -25,7 +25,7 @@ const YouthList: React.FC<Props> = ({
     );
   }
   return (
-    <div className={cn('grid auto-rows-fr gap-4 md:grid-cols-2 xl:grid-cols-3', className)}>
+    <div className={cn('grid gap-4 md:grid-cols-2 xl:grid-cols-3', className)}>
       {candidates.map((c) => (
         <YouthCandidateCard
           key={c.id}


### PR DESCRIPTION
## Summary
- remove fixed fractional row heights from the youth candidate grid so cards can expand with their content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e192ad4348832abf6cd74c1da9767b