### PR TITLE
Broaden youth candidate card buttons

### DIFF
--- a/src/features/youth/YouthCandidateCard.tsx
+++ b/src/features/youth/YouthCandidateCard.tsx
@@ -43,7 +43,7 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
   return (
     <Card
       data-testid={`youth-candidate-${candidate.id}`}
-      className="group relative flex h-full flex-col overflow-hidden border border-white/10 bg-slate-900/70 p-5 text-slate-100 shadow-lg backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-xl"
+      className="group relative flex h-full min-h-[340px] flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-900/75 p-6 text-slate-100 shadow-xl backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-2xl sm:p-7 md:min-h-[380px] xl:min-w-[320px]"
     >
       <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
         <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/10 via-transparent to-emerald-500/20" />
@@ -58,7 +58,7 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
           </div>
         </div>
         <div className="min-w-0 flex flex-1 flex-col">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
               <h3 className="truncate text-base font-semibold tracking-tight">{player.name}</h3>
               <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
@@ -91,13 +91,13 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                 </div>
               </div>
             </div>
-            <div className="flex flex-wrap gap-2">
+            <div className="order-last mt-2 flex flex-col gap-2 sm:order-none sm:flex-row sm:flex-wrap sm:justify-end">
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => onAccept(candidate.id)}
                 data-testid={`youth-accept-${candidate.id}`}
-                className="rounded-full border border-transparent bg-white/5 px-4 text-xs font-semibold text-cyan-100 shadow-sm transition hover:border-cyan-400/60 hover:bg-cyan-500/20 hover:text-white"
+                className="w-full rounded-full border border-cyan-400/40 bg-cyan-500/20 px-4 py-2 text-xs font-semibold text-cyan-50 shadow-lg shadow-cyan-500/20 transition hover:border-cyan-300 hover:bg-cyan-500/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 sm:w-auto"
               >
                 Takıma Al
               </Button>
@@ -106,7 +106,7 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                 size="sm"
                 onClick={() => onRelease(candidate.id)}
                 data-testid={`youth-release-${candidate.id}`}
-                className="rounded-full border border-transparent bg-white/5 px-4 text-xs font-semibold text-slate-200 shadow-sm transition hover:border-rose-500/60 hover:bg-rose-500/20 hover:text-white"
+                className="w-full rounded-full border border-rose-500/40 bg-rose-500/15 px-4 py-2 text-xs font-semibold text-rose-100 shadow-lg shadow-rose-500/15 transition hover:border-rose-400 hover:bg-rose-500/25 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 sm:w-auto"
               >
                 Serbest Bırak
               </Button>


### PR DESCRIPTION
## Summary
- expand the youth candidate card spacing and minimum dimensions so content remains visible inside the card
- restyle the accept and release controls with higher contrast backgrounds and focus states so they stand out against the card

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e1941efbb8832aa0041b0a8410157d