### PR TITLE
Adjust youth candidate cards sizing

### DIFF
--- a/src/features/youth/YouthCandidateCard.tsx
+++ b/src/features/youth/YouthCandidateCard.tsx
@@ -43,28 +43,29 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
   return (
     <Card
       data-testid={`youth-candidate-${candidate.id}`}
- className="group relative flex h-full min-h-[340px] flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-900/75 p-6 text-slate-100 shadow-xl backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-2xl sm:p-7 md:min-h-[380px] xl:min-w-[320px]"    >
+      className="group relative flex h-full min-h-[280px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-900/75 p-4 text-slate-100 shadow-lg backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-2xl sm:p-5 md:min-h-[320px] xl:min-w-[260px]"
+    >
       <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
         <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/10 via-transparent to-emerald-500/20" />
       </div>
-      <div className="relative flex flex-1 flex-col gap-4 sm:flex-row sm:items-start">
+      <div className="relative flex flex-1 flex-col gap-3 sm:flex-row sm:items-start">
         <div className="relative shrink-0">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-500 to-emerald-500 text-lg font-semibold text-white shadow-lg shadow-cyan-500/20">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-500 to-emerald-500 text-base font-semibold text-white shadow-lg shadow-cyan-500/20">
             {initials}
           </div>
-          <div className="absolute -bottom-1 -right-1 flex h-7 w-7 items-center justify-center rounded-full border border-white/20 bg-slate-950/80 text-[11px] font-bold text-cyan-100 shadow-md shadow-cyan-500/20">
+          <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border border-white/20 bg-slate-950/80 text-[10px] font-bold text-cyan-100 shadow-md shadow-cyan-500/20">
             {player.position}
           </div>
         </div>
         <div className="min-w-0 flex flex-1 flex-col">
-  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div>
               <h3 className="truncate text-base font-semibold tracking-tight">{player.name}</h3>
-              <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+              <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs">
                 <Badge variant="secondary" className="border-white/20 bg-white/10 text-white backdrop-blur">
                   {player.age} yaş
                 </Badge>
-                <div className="flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-1 text-[11px] font-medium text-cyan-100 shadow-inner shadow-cyan-500/10">
+                <div className="flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-0.5 text-[11px] font-medium text-cyan-100 shadow-inner shadow-cyan-500/10">
                   <TrendingUp className="h-3 w-3" />
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -90,13 +91,13 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                 </div>
               </div>
             </div>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-1.5">
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => onAccept(candidate.id)}
                 data-testid={`youth-accept-${candidate.id}`}
-                className="rounded-full border border-transparent bg-white/5 px-4 text-xs font-semibold text-cyan-100 shadow-sm transition hover:border-cyan-400/60 hover:bg-cyan-500/20 hover:text-white"
+                className="rounded-full border border-transparent bg-white/5 px-3 text-xs font-semibold text-cyan-100 shadow-sm transition hover:border-cyan-400/60 hover:bg-cyan-500/20 hover:text-white"
               >
                 Takıma Al
               </Button>
@@ -105,7 +106,7 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                 size="sm"
                 onClick={() => onRelease(candidate.id)}
                 data-testid={`youth-release-${candidate.id}`}
-                className="rounded-full border border-transparent bg-white/5 px-4 text-xs font-semibold text-slate-200 shadow-sm transition hover:border-rose-500/60 hover:bg-rose-500/20 hover:text-white"
+                className="rounded-full border border-transparent bg-white/5 px-3 text-xs font-semibold text-slate-200 shadow-sm transition hover:border-rose-500/60 hover:bg-rose-500/20 hover:text-white"
               >
                 Serbest Bırak
               </Button>
@@ -117,7 +118,7 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
                 <StatBar key={label} label={label} value={value} className="text-slate-200" />
               ))}
             </div>
-            <div className="mt-3 hidden space-y-1 text-xs text-slate-300 group-hover:block">
+            <div className="mt-3 hidden space-y-1 text-[11px] text-slate-300 group-hover:block">
               {extraStats.map(([label, value]) => (
                 <StatBar key={label} label={label} value={value} className="text-slate-200" />
               ))}


### PR DESCRIPTION
## Summary
- reduce the youth candidate card minimum dimensions and padding to better fit the layout
- tighten spacing and control sizing so the details remain readable on the smaller cards

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e1983e1710832a89925a04ac121a0e