### PR TITLE
Adjust youth layout for better card fit

### DIFF
--- a/src/features/youth/YouthCandidateCard.tsx
+++ b/src/features/youth/YouthCandidateCard.tsx
@@ -43,7 +43,7 @@ const YouthCandidateCard: React.FC<Props> = ({ candidate, onAccept, onRelease })
   return (
     <Card
       data-testid={`youth-candidate-${candidate.id}`}
-      className="group relative flex h-full min-h-[280px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-900/75 p-4 text-slate-100 shadow-lg backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-2xl sm:p-5 md:min-h-[320px] xl:min-w-[260px]"
+      className="group relative flex h-full min-h-[280px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-900/75 p-4 text-slate-100 shadow-lg backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-2xl sm:p-5 md:min-h-[320px] xl:min-w-0"
     >
       <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
         <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/10 via-transparent to-emerald-500/20" />

--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -270,7 +270,7 @@ const YouthPage = () => {
         aria-hidden
       />
       <div className="relative z-10 px-4 py-10 sm:px-6 lg:px-8">
-        <div className="relative mx-auto max-w-6xl rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-6 py-8 shadow-2xl">
+        <div className="relative mx-auto max-w-7xl rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-6 py-8 shadow-2xl">
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),_transparent_60%)]" />
           <div className="pointer-events-none absolute -left-24 bottom-0 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
           <div className="pointer-events-none absolute right-[-10%] top-[-20%] h-72 w-72 rounded-full bg-cyan-500/25 blur-3xl" />
@@ -329,7 +329,7 @@ const YouthPage = () => {
                   candidates={candidates}
                   onAccept={handleAccept}
                   onRelease={handleRelease}
-                  className="2xl:grid-cols-3"
+                  className="2xl:grid-cols-4"
                   emptyStateClassName="text-slate-300"
                 />
               </div>


### PR DESCRIPTION
## Summary
- expand youth page container width to give more room for candidate cards
- allow four-column layout on very wide screens and remove extra min-width constraint from cards to avoid overflow

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e19cc94ddc832abaadff6f6f5cdef0