### PR TITLE
Align main menu and topbar with nostalgia theme

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -40,6 +40,7 @@ import type { KitType } from '@/types';
 import { KIT_CONFIG, formatKitEffect } from '@/lib/kits';
 import KitUsageDialog from '@/components/kit/KitUsageDialog';
 import { toast } from 'sonner';
+import '@/styles/nostalgia-theme.css';
 
 const KIT_ICONS: Record<KitType, { icon: LucideIcon; color: string }> = {
   energy: { icon: BatteryCharging, color: 'text-emerald-500' },
@@ -226,30 +227,36 @@ const TopBar = () => {
   };
 
   return (
-    <header className="w-full border-b bg-background/60 px-3 py-3 backdrop-blur-sm">
-      <div className="flex flex-col gap-4">
+    <header className="nostalgia-topbar px-3 py-3 sm:px-4">
+      <div className="nostalgia-topbar__inner flex flex-col gap-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
             <button
               type="button"
               onClick={() => navigate('/')}
-              className="flex shrink-0 items-center rounded-md border border-transparent p-1 transition hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              className="flex shrink-0 items-center rounded-xl border border-white/10 bg-white/5 p-1 transition hover:border-cyan-300/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/40"
               aria-label="Ana menuye don"
             >
               <AppLogo size="sm" showText textClassName="hidden xl:inline" />
             </button>
 
             {user ? (
-              <div className="flex min-w-0 flex-col items-start gap-1 text-sm text-muted-foreground sm:flex-row sm:items-center sm:gap-3">
+              <div className="flex min-w-0 flex-col items-start gap-1 text-sm text-slate-200 sm:flex-row sm:items-center sm:gap-4">
                 <div className="flex items-center gap-2">
                   <span className="text-2xl leading-none">{user.teamLogo}</span>
                   <span className="truncate text-base font-semibold text-foreground sm:text-lg">{user.teamName}</span>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant="secondary" className="px-2 py-0.5 text-[11px] sm:text-xs">
+                  <Badge
+                    variant="secondary"
+                    className="border border-white/20 bg-white/10 px-2 py-0.5 text-[11px] text-slate-100 shadow-sm backdrop-blur-sm sm:text-xs"
+                  >
                     Overall: {teamOverall ?? '-'}
                   </Badge>
-                  <Badge variant="outline" className="px-2 py-0.5 text-[11px] sm:text-xs">
+                  <Badge
+                    variant="outline"
+                    className="border border-white/20 bg-white/5 px-2 py-0.5 text-[11px] text-slate-100 sm:text-xs"
+                  >
                     Form: {teamForm ?? '-'}
                   </Badge>
                 </div>
@@ -267,10 +274,19 @@ const TopBar = () => {
               return (
                 <DropdownMenu key={type}>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="sm" className="flex items-center gap-2 whitespace-nowrap">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="flex items-center gap-2 whitespace-nowrap text-slate-200 hover:bg-white/10 hover:text-white"
+                    >
                       <Icon className={`h-4 w-4 ${color}`} />
                       <span className="text-sm font-medium">{config.label}</span>
-                      <Badge variant={count > 0 ? 'secondary' : 'outline'}>{count}</Badge>
+                      <Badge
+                        variant={count > 0 ? 'secondary' : 'outline'}
+                        className="border border-white/20 bg-white/10 px-1.5 py-0 text-[11px] text-slate-100"
+                      >
+                        {count}
+                      </Badge>
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="start" className="w-64">
@@ -300,12 +316,17 @@ const TopBar = () => {
 
         <div className="flex flex-wrap items-center gap-2 sm:justify-end">
           <div className="flex items-center gap-2">
-            <Button variant="ghost" size="sm" onClick={toggleTheme}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={toggleTheme}
+              className="text-slate-200 hover:bg-white/10 hover:text-white"
+            >
               {theme === 'light' ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
             </Button>
             <Popover>
               <PopoverTrigger asChild>
-                <Button variant="ghost" size="sm">
+                <Button variant="ghost" size="sm" className="text-slate-200 hover:bg-white/10 hover:text-white">
                   <div className="relative">
                     <Bell className="h-4 w-4" />
                     {notifications.length > 0 && (
@@ -329,21 +350,27 @@ const TopBar = () => {
                 )}
               </PopoverContent>
             </Popover>
-            <Button variant="ghost" size="sm" onClick={logout}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={logout}
+              className="text-slate-200 hover:bg-white/10 hover:text-white"
+            >
               <LogOut className="h-4 w-4" />
             </Button>
           </div>
 
-          {isProcessing && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+          {isProcessing && <Loader2 className="h-4 w-4 animate-spin text-slate-300" />}
           <div className="flex items-center gap-1" data-testid="topbar-diamond-balance">
-            <Diamond className="h-5 w-5 text-blue-500" />
-            <span>{balance}</span>
+            <Diamond className="h-5 w-5 text-sky-300 drop-shadow" />
+            <span className="text-slate-100">{balance}</span>
           </div>
           <Button
             variant="ghost"
             size="icon"
             onClick={() => navigate('/store/diamonds')}
             data-testid="topbar-diamond-plus"
+            className="text-slate-200 hover:bg-white/10 hover:text-white"
           >
             <Plus className="h-4 w-4" />
           </Button>

--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -17,21 +17,22 @@ import {
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getMyLeagueId, listLeagueStandings, getFixturesForTeam } from '@/services/leagues';
+import '@/styles/nostalgia-theme.css';
 
 const menuItems = [
-  { id: 'team-planning', label: 'Takim Plani', icon: Users, color: 'bg-blue-500' },
-  { id: 'youth', label: 'Altyapi', icon: UserPlus, color: 'bg-green-500' },
-  { id: 'transfer-market', label: 'Transfer Pazari', icon: ShoppingCart, color: 'bg-teal-500' },
-  { id: 'fixtures', label: 'Fikstur', icon: Calendar, color: 'bg-purple-500' },
-  { id: 'leagues', label: 'Ligler', icon: Trophy, color: 'bg-yellow-500' },
-  { id: 'training', label: 'Antrenman', icon: Dumbbell, color: 'bg-orange-500' },
-  { id: 'match-preview', label: 'Mac Onizleme', icon: Play, color: 'bg-red-500' },
-  { id: 'match-simulation', label: 'Mac Simulasyonu', icon: Play, color: 'bg-red-600' },
-  { id: 'match-history', label: 'Gecmis Maclar', icon: History, color: 'bg-gray-500' },
-  { id: 'finance', label: 'Finans', icon: DollarSign, color: 'bg-emerald-500' },
-  { id: 'profile', label: 'Kisisel Bilgiler', icon: User, color: 'bg-indigo-500' },
-  { id: 'settings', label: 'Ayarlar', icon: Settings, color: 'bg-slate-500' },
-  { id: 'legend-pack', label: 'Nostalji Paket', icon: Star, color: 'bg-pink-500' },
+  { id: 'team-planning', label: 'Takim Plani', icon: Users, accent: 'sky' },
+  { id: 'youth', label: 'Altyapi', icon: UserPlus, accent: 'emerald' },
+  { id: 'transfer-market', label: 'Transfer Pazari', icon: ShoppingCart, accent: 'teal' },
+  { id: 'fixtures', label: 'Fikstur', icon: Calendar, accent: 'violet' },
+  { id: 'leagues', label: 'Ligler', icon: Trophy, accent: 'gold' },
+  { id: 'training', label: 'Antrenman', icon: Dumbbell, accent: 'orange' },
+  { id: 'match-preview', label: 'Mac Onizleme', icon: Play, accent: 'rose' },
+  { id: 'match-simulation', label: 'Mac Simulasyonu', icon: Play, accent: 'purple' },
+  { id: 'match-history', label: 'Gecmis Maclar', icon: History, accent: 'slate' },
+  { id: 'finance', label: 'Finans', icon: DollarSign, accent: 'cyan' },
+  { id: 'profile', label: 'Kisisel Bilgiler', icon: User, accent: 'indigo' },
+  { id: 'settings', label: 'Ayarlar', icon: Settings, accent: 'teal' },
+  { id: 'legend-pack', label: 'Nostalji Paket', icon: Star, accent: 'pink' },
 ];
 
 export default function MainMenu() {
@@ -88,49 +89,58 @@ export default function MainMenu() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 dark:from-green-950 dark:via-emerald-950 dark:to-teal-950">
-      <div className="p-4">
-        <div className="grid grid-cols-2 gap-4 max-w-2xl mx-auto">
+    <div className="nostalgia-screen">
+      <div className="nostalgia-screen__gradient" aria-hidden />
+      <div className="nostalgia-screen__orb nostalgia-screen__orb--left" aria-hidden />
+      <div className="nostalgia-screen__orb nostalgia-screen__orb--right" aria-hidden />
+      <div className="nostalgia-screen__noise" aria-hidden />
+      <div className="nostalgia-screen__content">
+        <header className="nostalgia-main-menu__header">
+          <div>
+            <h1 className="nostalgia-main-menu__title">Ana Menü</h1>
+            <p className="nostalgia-main-menu__subtitle">
+              Kulübünün tüm kritik operasyonlarına tek ekrandan ulaş.
+            </p>
+          </div>
+        </header>
+
+        <section className="nostalgia-main-menu__grid">
           {menuItems.map((item) => (
             <Card
               key={item.id}
-              className="hover:shadow-lg transition-all duration-200 cursor-pointer hover:scale-105"
+              className="nostalgia-card cursor-pointer"
               onClick={() => handleMenuClick(item.id)}
             >
-              <CardContent className="p-6 text-center">
-                <div className={`w-12 h-12 ${item.color} rounded-full flex items-center justify-center mx-auto mb-3`}>
-
-                  <item.icon className="h-6 w-6 text-white" />
+              <CardContent className="nostalgia-card__content">
+                <div className={`nostalgia-menu-icon nostalgia-menu-icon--${item.accent}`}>
+                  <item.icon />
                 </div>
-                <h3 className="font-semibold text-sm">{item.label}</h3>
+                <h3 className="nostalgia-card__label">{item.label}</h3>
               </CardContent>
             </Card>
           ))}
-        </div>
+        </section>
 
-        <div className="mt-8 max-w-2xl mx-auto">
-          <h2 className="text-lg font-semibold mb-4">Hizli Bakis</h2>
-          <div className="grid grid-cols-3 gap-4">
-            <Card>
-              <CardContent className="p-4 text-center">
-                <div className="text-2xl font-bold text-green-600">{leaguePosition ?? '-'}{leaguePosition ? '.' : ''}</div>
-                <div className="text-sm text-muted-foreground">Lig Sirasi</div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4 text-center">
-                <div className="text-2xl font-bold text-blue-600">{leaguePoints ?? '-'}</div>
-                <div className="text-sm text-muted-foreground">Puan</div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4 text-center">
-                <div className="text-2xl font-bold text-purple-600">{hoursToNextMatch ?? '-'}</div>
-                <div className="text-sm text-muted-foreground">Saat Sonra</div>
-              </CardContent>
-            </Card>
+        <section className="nostalgia-quick-panel">
+          <h2 className="nostalgia-quick-panel__title">Hızlı Bakış</h2>
+          <div className="nostalgia-quick-grid">
+            <div className="nostalgia-quick-card">
+              <span className="nostalgia-quick-card__value text-emerald-300">
+                {leaguePosition ?? '-'}
+                {leaguePosition ? '.' : ''}
+              </span>
+              <span className="nostalgia-quick-card__label">Lig Sırası</span>
+            </div>
+            <div className="nostalgia-quick-card">
+              <span className="nostalgia-quick-card__value text-sky-300">{leaguePoints ?? '-'}</span>
+              <span className="nostalgia-quick-card__label">Puan</span>
+            </div>
+            <div className="nostalgia-quick-card">
+              <span className="nostalgia-quick-card__value text-fuchsia-300">{hoursToNextMatch ?? '-'}</span>
+              <span className="nostalgia-quick-card__label">Saat Sonra</span>
+            </div>
           </div>
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/src/styles/nostalgia-theme.css
+++ b/src/styles/nostalgia-theme.css
@@ -1,0 +1,314 @@
+.nostalgia-screen {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background: radial-gradient(circle at top left, #1e1b4b 0%, #0f172a 45%, #020617 100%);
+  color: #e2e8f0;
+}
+
+.nostalgia-screen__gradient {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(236, 72, 153, 0.18));
+  mix-blend-mode: screen;
+  animation: nostalgia-gradient 16s ease-in-out infinite alternate;
+}
+
+.nostalgia-screen__orb {
+  position: absolute;
+  width: clamp(320px, 40vw, 520px);
+  height: clamp(320px, 40vw, 520px);
+  border-radius: 50%;
+  filter: blur(60px);
+  opacity: 0.55;
+  animation: nostalgia-orb-drift 24s ease-in-out infinite alternate;
+}
+
+.nostalgia-screen__orb--left {
+  top: -20%;
+  left: -10%;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.85) 0%, rgba(56, 189, 248, 0) 65%);
+}
+
+.nostalgia-screen__orb--right {
+  bottom: -25%;
+  right: -5%;
+  background: radial-gradient(circle, rgba(192, 132, 252, 0.8) 0%, rgba(192, 132, 252, 0) 70%);
+  animation-delay: 6s;
+}
+
+.nostalgia-screen__noise {
+  position: absolute;
+  inset: 0;
+  opacity: 0.08;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.18) 1px, transparent 0);
+  background-size: 4px 4px;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.nostalgia-screen__content {
+  position: relative;
+  z-index: 1;
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: clamp(3rem, 4vw, 4.5rem) clamp(1.5rem, 4vw, 3.5rem) clamp(4rem, 6vw, 6rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.nostalgia-main-menu__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .nostalgia-main-menu__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.nostalgia-main-menu__title {
+  font-size: clamp(2.1rem, 3vw, 2.9rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.nostalgia-main-menu__subtitle {
+  margin-top: 0.4rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.72);
+  max-width: 28rem;
+}
+
+.nostalgia-main-menu__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.35rem;
+}
+
+.nostalgia-card {
+  position: relative;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  box-shadow: 0 30px 60px rgba(6, 12, 31, 0.45);
+  backdrop-filter: blur(18px);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  color: #f8fafc;
+}
+
+.nostalgia-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(236, 72, 153, 0.12));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.nostalgia-card:hover {
+  transform: translateY(-6px) scale(1.02);
+  border-color: rgba(236, 72, 153, 0.4);
+  box-shadow: 0 40px 70px rgba(8, 11, 27, 0.55);
+}
+
+.nostalgia-card:hover::before {
+  opacity: 1;
+}
+
+.nostalgia-card__content {
+  position: relative;
+  z-index: 1;
+  padding: 1.75rem 1.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.nostalgia-menu-icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 20px 35px rgba(14, 165, 233, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: #0b1120;
+}
+
+.nostalgia-menu-icon svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.nostalgia-menu-icon--cyan {
+  background: linear-gradient(135deg, #67e8f9, #0ea5e9);
+}
+
+.nostalgia-menu-icon--emerald {
+  background: linear-gradient(135deg, #6ee7b7, #059669);
+  box-shadow: 0 20px 35px rgba(16, 185, 129, 0.3);
+}
+
+.nostalgia-menu-icon--teal {
+  background: linear-gradient(135deg, #5eead4, #0d9488);
+  box-shadow: 0 20px 35px rgba(13, 148, 136, 0.3);
+}
+
+.nostalgia-menu-icon--violet {
+  background: linear-gradient(135deg, #a855f7, #7c3aed);
+  box-shadow: 0 20px 35px rgba(124, 58, 237, 0.3);
+}
+
+.nostalgia-menu-icon--gold {
+  background: linear-gradient(135deg, #facc15, #f97316);
+  box-shadow: 0 20px 35px rgba(245, 158, 11, 0.3);
+}
+
+.nostalgia-menu-icon--orange {
+  background: linear-gradient(135deg, #fb923c, #ea580c);
+  box-shadow: 0 20px 35px rgba(234, 88, 12, 0.3);
+}
+
+.nostalgia-menu-icon--rose {
+  background: linear-gradient(135deg, #fb7185, #f43f5e);
+  box-shadow: 0 20px 35px rgba(244, 63, 94, 0.3);
+}
+
+.nostalgia-menu-icon--slate {
+  background: linear-gradient(135deg, #94a3b8, #475569);
+  box-shadow: 0 20px 35px rgba(71, 85, 105, 0.3);
+  color: #0f172a;
+}
+
+.nostalgia-menu-icon--indigo {
+  background: linear-gradient(135deg, #818cf8, #4f46e5);
+  box-shadow: 0 20px 35px rgba(79, 70, 229, 0.3);
+}
+
+.nostalgia-menu-icon--pink {
+  background: linear-gradient(135deg, #f472b6, #db2777);
+  box-shadow: 0 20px 35px rgba(219, 39, 119, 0.32);
+}
+
+.nostalgia-menu-icon--sky {
+  background: linear-gradient(135deg, #7dd3fc, #2563eb);
+  box-shadow: 0 20px 35px rgba(37, 99, 235, 0.34);
+}
+
+.nostalgia-menu-icon--purple {
+  background: linear-gradient(135deg, #c084fc, #9333ea);
+  box-shadow: 0 20px 35px rgba(147, 51, 234, 0.32);
+}
+
+.nostalgia-card__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.nostalgia-quick-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.nostalgia-quick-panel__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.015em;
+}
+
+.nostalgia-quick-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.2rem;
+}
+
+.nostalgia-quick-card {
+  border-radius: 18px;
+  background: rgba(8, 15, 32, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 50px rgba(4, 10, 27, 0.42);
+  backdrop-filter: blur(16px);
+  text-align: center;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #e2e8f0;
+}
+
+.nostalgia-quick-card__value {
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.nostalgia-quick-card__label {
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.nostalgia-topbar {
+  position: relative;
+  width: 100%;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.72);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(18px);
+  overflow: hidden;
+}
+
+.nostalgia-topbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.14), rgba(236, 72, 153, 0.14));
+  mix-blend-mode: screen;
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.nostalgia-topbar__inner {
+  position: relative;
+  z-index: 1;
+  color: #e2e8f0;
+}
+
+.nostalgia-topbar__inner .text-muted-foreground {
+  color: rgba(203, 213, 225, 0.78);
+}
+
+.nostalgia-topbar__inner .text-foreground {
+  color: #f8fafc;
+}
+
+@keyframes nostalgia-gradient {
+  0% {
+    transform: scale(1) translate3d(0, 0, 0);
+  }
+  100% {
+    transform: scale(1.08) translate3d(2%, -1.5%, 0);
+  }
+}
+
+@keyframes nostalgia-orb-drift {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(6%, -4%, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable nostalgia theme stylesheet that mirrors the legend pack aesthetic
- restyle the main menu grid and quick stats using the nostalgia background, glass cards, and accent icons
- update the top bar to reuse the nostalgia styling, including translucent controls and refreshed button/badge treatments

## Testing
- pnpm dev --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e2e88ab978832aac25687dbcb8fefd