### PR TITLE
Enhance nostalgia main menu cards

### DIFF
--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -108,9 +108,10 @@ export default function MainMenu() {
           {menuItems.map((item) => (
             <Card
               key={item.id}
-              className="nostalgia-card cursor-pointer"
+              className={`nostalgia-card nostalgia-card--${item.accent} cursor-pointer`}
               onClick={() => handleMenuClick(item.id)}
             >
+              <span className="nostalgia-card__halo" aria-hidden />
               <CardContent className="nostalgia-card__content">
                 <div className={`nostalgia-menu-icon nostalgia-menu-icon--${item.accent}`}>
                   <item.icon />

--- a/src/styles/nostalgia-theme.css
+++ b/src/styles/nostalgia-theme.css
@@ -92,13 +92,18 @@
 }
 
 .nostalgia-card {
+  --nostalgia-accent: 94, 234, 212;
+  --nostalgia-accent-strong: 45, 212, 191;
   position: relative;
-  border-radius: 20px;
-  background: rgba(15, 23, 42, 0.62);
-  border: 1px solid rgba(94, 234, 212, 0.18);
-  box-shadow: 0 30px 60px rgba(6, 12, 31, 0.45);
-  backdrop-filter: blur(18px);
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  border-radius: 22px;
+  background: rgba(13, 20, 41, 0.68);
+  border: 1px solid rgba(var(--nostalgia-accent), 0.22);
+  box-shadow:
+    0 28px 55px rgba(6, 12, 31, 0.5),
+    0 18px 32px rgba(var(--nostalgia-accent), 0.12);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+  transition: transform 0.28s ease, box-shadow 0.28s ease, border-color 0.28s ease;
   color: #f8fafc;
 }
 
@@ -107,48 +112,105 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(236, 72, 153, 0.12));
+  background: linear-gradient(
+    135deg,
+    rgba(var(--nostalgia-accent), 0.16),
+    rgba(var(--nostalgia-accent-strong), 0.18)
+  );
   opacity: 0;
   transition: opacity 0.25s ease;
   pointer-events: none;
 }
 
 .nostalgia-card:hover {
-  transform: translateY(-6px) scale(1.02);
-  border-color: rgba(236, 72, 153, 0.4);
-  box-shadow: 0 40px 70px rgba(8, 11, 27, 0.55);
+  transform: translateY(-7px) scale(1.02);
+  border-color: rgba(var(--nostalgia-accent-strong), 0.55);
+  box-shadow:
+    0 45px 85px rgba(8, 11, 27, 0.6),
+    0 28px 50px rgba(var(--nostalgia-accent-strong), 0.22);
 }
 
 .nostalgia-card:hover::before {
   opacity: 1;
 }
 
+.nostalgia-card__halo {
+  position: absolute;
+  inset: -18% -18% 50% -18%;
+  border-radius: 60%;
+  background: radial-gradient(
+    120% 120% at 50% 15%,
+    rgba(var(--nostalgia-accent-strong), 0.32),
+    transparent 65%
+  );
+  opacity: 0.45;
+  filter: blur(0.5px);
+  mix-blend-mode: screen;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.nostalgia-card:hover .nostalgia-card__halo {
+  opacity: 0.75;
+  transform: translate3d(0, -6px, 0) scale(1.04);
+}
+
 .nostalgia-card__content {
   position: relative;
   z-index: 1;
-  padding: 1.75rem 1.5rem;
+  padding: 1.85rem 1.65rem;
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.85rem;
+  gap: 0.95rem;
 }
 
 .nostalgia-menu-icon {
+  position: relative;
+  isolation: isolate;
   width: 3rem;
   height: 3rem;
   border-radius: 9999px;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 20px 35px rgba(14, 165, 233, 0.3);
+  box-shadow: 0 20px 35px rgba(var(--nostalgia-accent-strong), 0.28);
   border: 1px solid rgba(255, 255, 255, 0.22);
   color: #0b1120;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .nostalgia-menu-icon svg {
   width: 1.5rem;
   height: 1.5rem;
+}
+
+.nostalgia-menu-icon::after {
+  content: '';
+  position: absolute;
+  inset: -0.45rem;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--nostalgia-accent), 0.45),
+    rgba(var(--nostalgia-accent-strong), 0.85)
+  );
+  opacity: 0;
+  filter: blur(12px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: -1;
+}
+
+.nostalgia-card:hover .nostalgia-menu-icon {
+  transform: translateY(-4px) scale(1.05);
+  box-shadow: 0 24px 40px rgba(var(--nostalgia-accent-strong), 0.3);
+}
+
+.nostalgia-card:hover .nostalgia-menu-icon::after {
+  opacity: 0.85;
+  transform: scale(1.05);
 }
 
 .nostalgia-menu-icon--cyan {
@@ -211,10 +273,77 @@
   box-shadow: 0 20px 35px rgba(147, 51, 234, 0.32);
 }
 
+.nostalgia-card--sky {
+  --nostalgia-accent: 125, 211, 252;
+  --nostalgia-accent-strong: 37, 99, 235;
+}
+
+.nostalgia-card--emerald {
+  --nostalgia-accent: 110, 231, 183;
+  --nostalgia-accent-strong: 5, 150, 105;
+}
+
+.nostalgia-card--teal {
+  --nostalgia-accent: 94, 234, 212;
+  --nostalgia-accent-strong: 13, 148, 136;
+}
+
+.nostalgia-card--violet {
+  --nostalgia-accent: 168, 85, 247;
+  --nostalgia-accent-strong: 124, 58, 237;
+}
+
+.nostalgia-card--gold {
+  --nostalgia-accent: 250, 204, 21;
+  --nostalgia-accent-strong: 249, 115, 22;
+}
+
+.nostalgia-card--orange {
+  --nostalgia-accent: 251, 146, 60;
+  --nostalgia-accent-strong: 234, 88, 12;
+}
+
+.nostalgia-card--rose {
+  --nostalgia-accent: 251, 113, 133;
+  --nostalgia-accent-strong: 244, 63, 94;
+}
+
+.nostalgia-card--slate {
+  --nostalgia-accent: 148, 163, 184;
+  --nostalgia-accent-strong: 71, 85, 105;
+}
+
+.nostalgia-card--cyan {
+  --nostalgia-accent: 103, 232, 249;
+  --nostalgia-accent-strong: 14, 165, 233;
+}
+
+.nostalgia-card--indigo {
+  --nostalgia-accent: 129, 140, 248;
+  --nostalgia-accent-strong: 79, 70, 229;
+}
+
+.nostalgia-card--pink {
+  --nostalgia-accent: 244, 114, 182;
+  --nostalgia-accent-strong: 219, 39, 119;
+}
+
+.nostalgia-card--purple {
+  --nostalgia-accent: 192, 132, 252;
+  --nostalgia-accent-strong: 147, 51, 234;
+}
+
 .nostalgia-card__label {
   font-size: 0.95rem;
   font-weight: 600;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.82);
+  transition: color 0.3s ease;
+}
+
+.nostalgia-card:hover .nostalgia-card__label {
+  color: #f8fafc;
 }
 
 .nostalgia-quick-panel {


### PR DESCRIPTION
## Summary
- add accent-specific styling hooks to the main menu cards
- refresh the nostalgia theme with accent-driven glows and hover motion for each tile

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ec8a0058832ab28935b65de8bd8b