### PR TITLE
Add info popup buttons for empty state explanations

### DIFF
--- a/src/components/ui/info-popup-button.tsx
+++ b/src/components/ui/info-popup-button.tsx
@@ -1,0 +1,62 @@
+import { AlertCircle } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+export interface InfoPopupButtonProps {
+  message: React.ReactNode;
+  title?: string;
+  triggerLabel?: string;
+  triggerClassName?: string;
+  contentClassName?: string;
+}
+
+const InfoPopupButton: React.FC<InfoPopupButtonProps> = ({
+  message,
+  title = 'Bilgi',
+  triggerLabel = 'Bilgi mesajını görüntüle',
+  triggerClassName,
+  contentClassName,
+}) => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          aria-label={triggerLabel}
+          className={cn(
+            'flex h-9 w-9 items-center justify-center rounded-full border border-white/20 bg-white/10 text-cyan-200 transition hover:border-cyan-300 hover:bg-cyan-500/10 hover:text-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-400/60 focus:ring-offset-2 focus:ring-offset-slate-950',
+            triggerClassName,
+          )}
+        >
+          <AlertCircle className="h-4 w-4" />
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        className={cn(
+          'max-w-sm border border-white/10 bg-slate-950/95 text-left text-slate-100 shadow-2xl backdrop-blur',
+          contentClassName,
+        )}
+      >
+        <DialogHeader className="space-y-2">
+          <DialogTitle className="text-lg font-semibold text-white">{title}</DialogTitle>
+          <DialogDescription className="text-sm text-slate-300">
+            {message}
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default InfoPopupButton;

--- a/src/features/academy/CandidatesList.tsx
+++ b/src/features/academy/CandidatesList.tsx
@@ -1,4 +1,5 @@
 import CandidateCard from './CandidateCard';
+import InfoPopupButton from '@/components/ui/info-popup-button';
 import { AcademyCandidate } from '@/services/academy';
 
 interface Props {
@@ -9,7 +10,15 @@ interface Props {
 
 const CandidatesList: React.FC<Props> = ({ candidates, onAccept, onRelease }) => {
   if (candidates.length === 0) {
-    return <p className="text-sm text-muted-foreground">Henüz aday yok</p>;
+    return (
+      <div className="flex justify-center py-6">
+        <InfoPopupButton
+          title="Altyapı Adayları"
+          triggerLabel="Altyapı adayı yokken bilgi mesajını aç"
+          message="Henüz aday yok"
+        />
+      </div>
+    );
   }
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/src/features/legends/LegendPackPage.tsx
+++ b/src/features/legends/LegendPackPage.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useDiamonds } from '@/contexts/DiamondContext';
 import { Button } from '@/components/ui/button';
 import { BackButton } from '@/components/ui/back-button';
+import InfoPopupButton from '@/components/ui/info-popup-button';
 import { toast } from 'sonner';
 import LegendCard from './LegendCard';
 import { LEGEND_PLAYERS, type LegendPlayer } from './players';
@@ -284,7 +285,13 @@ const LegendPackPage = () => {
               <LegendCard player={current} onRent={handleRent} onRelease={handleRelease} />
             ) : (
               <div className="legend-pack-placeholder">
-                Yeni bir efsane için paketi aç ve kartı kulübüne kat.
+                <InfoPopupButton
+                  title="Nostalji Paketi"
+                  triggerLabel="Yeni efsane kartı bilgisi"
+                  triggerClassName="h-12 w-12 rounded-2xl border-white/20 bg-transparent text-amber-200 hover:border-amber-300"
+                  contentClassName="bg-slate-950/95"
+                  message="Yeni bir efsane için paketi aç ve kartı kulübüne kat."
+                />
               </div>
             )}
           </section>
@@ -306,9 +313,15 @@ const LegendPackPage = () => {
               ))}
             </div>
           ) : (
-            <p className="legend-pack-empty">
-              Şu anda kiralanmış efsane oyuncun yok. Paketi açarak kadronu güçlendirebilirsin.
-            </p>
+            <div className="legend-pack-empty flex justify-center">
+              <InfoPopupButton
+                title="Kiralanan Efsaneler"
+                triggerLabel="Kiralanan efsaneler bilgisi"
+                triggerClassName="h-10 w-10 rounded-2xl border-white/20 bg-transparent text-cyan-200 hover:border-cyan-300"
+                contentClassName="bg-slate-950/95"
+                message="Şu anda kiralanmış efsane oyuncun yok. Paketi açarak kadronu güçlendirebilirsin."
+              />
+            </div>
           )}
         </section>
       </div>

--- a/src/features/youth/YouthList.tsx
+++ b/src/features/youth/YouthList.tsx
@@ -1,4 +1,5 @@
 import YouthCandidateCard from './YouthCandidateCard';
+import InfoPopupButton from '@/components/ui/info-popup-button';
 import { YouthCandidate } from '@/services/youth';
 import { cn } from '@/lib/utils';
 
@@ -19,9 +20,13 @@ const YouthList: React.FC<Props> = ({
 }) => {
   if (candidates.length === 0) {
     return (
-      <p className={cn('text-sm text-muted-foreground', emptyStateClassName)}>
-        Henüz altyapı oyuncusu yok. Yeni aday üret.
-      </p>
+      <div className={cn('flex justify-center py-6', emptyStateClassName)}>
+        <InfoPopupButton
+          title="Oyuncu Havuzu"
+          triggerLabel="Altyapı oyuncusu bulunmadığında bilgi mesajını aç"
+          message="Henüz altyapı oyuncusu yok. Yeni aday üret."
+        />
+      </div>
     );
   }
   return (

--- a/src/features/youth/YouthPage.tsx
+++ b/src/features/youth/YouthPage.tsx
@@ -21,6 +21,7 @@ import { generateRandomName } from '@/lib/names';
 import { calculateOverall, getRoles } from '@/lib/player';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import InfoPopupButton from '@/components/ui/info-popup-button';
 import YouthList from './YouthList';
 import CooldownPanel from './CooldownPanel';
 import type { Player } from '@/types';
@@ -82,10 +83,17 @@ const StatCard: React.FC<StatCardProps> = ({ icon: Icon, label, value, helper })
       <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900/70 text-cyan-200 shadow-inner shadow-cyan-500/20">
         <Icon className="h-5 w-5" />
       </div>
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/70">{label}</p>
+      <div className="flex-1">
+        <div className="flex items-center gap-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/70">{label}</p>
+          <InfoPopupButton
+            message={helper}
+            title={label}
+            triggerLabel={`${label} için bilgi mesajını aç`}
+            triggerClassName="h-7 w-7 rounded-lg border-white/15 bg-transparent text-cyan-200 hover:border-cyan-300"
+          />
+        </div>
         <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
-        <p className="mt-1 text-sm text-slate-300">{helper}</p>
       </div>
     </div>
   </div>

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -30,6 +30,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { BackButton } from '@/components/ui/back-button';
+import InfoPopupButton from '@/components/ui/info-popup-button';
 import { trainings } from '@/lib/data';
 import { runTrainingSimulation } from '@/lib/trainingSession';
 import { cn } from '@/lib/utils';
@@ -825,7 +826,13 @@ export default function TrainingPage() {
                     </div>
                     <div className="space-y-2 max-h-[calc(100vh-200px)] overflow-y-auto pr-2">
                       {filteredHistory.length === 0 && (
-                        <p className="text-sm text-muted-foreground">Kayıt yok</p>
+                        <div className="flex justify-center py-4">
+                          <InfoPopupButton
+                            title="Geçmiş Antrenmanlar"
+                            triggerLabel="Geçmiş antrenman kaydı bulunmadığında bilgi mesajını aç"
+                            message="Kayıt yok"
+                          />
+                        </div>
                       )}
                       {filteredHistory.map((rec, idx) => (
                         <div key={idx} className="border p-2 rounded">


### PR DESCRIPTION
## Summary
- create a reusable info popup icon button component
- replace inline empty state descriptions with the popup trigger on youth, academy, training, and legend pack pages

## Testing
- pnpm lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e434a3dc60832abcd5668aae56739a