### PR TITLE
feat: add team logo upload and restyle transfer market

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -242,8 +242,18 @@ const TopBar = () => {
 
             {user ? (
               <div className="flex min-w-0 flex-col items-start gap-1 text-sm text-slate-200 sm:flex-row sm:items-center sm:gap-4">
-                <div className="flex items-center gap-2">
-                  <span className="text-2xl leading-none">{user.teamLogo}</span>
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-emerald-300/30 bg-slate-900/70">
+                    {user.teamLogo && /^(data:image|https?:\/\/)/.test(user.teamLogo) ? (
+                      <img
+                        src={user.teamLogo}
+                        alt="Takım logosu"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-2xl leading-none">{user.teamLogo ?? '⚽'}</span>
+                    )}
+                  </div>
                   <span className="truncate text-base font-semibold text-foreground sm:text-lg">{user.teamName}</span>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+  useCallback,
+} from 'react';
 
 type Theme = 'light' | 'dark';
 
@@ -22,23 +29,25 @@ interface ThemeProviderProps {
 }
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
-  const [theme, setTheme] = useState<Theme>('light');
+  const [theme, setTheme] = useState<Theme>('dark');
 
-  useEffect(() => {
-    const savedTheme = localStorage.getItem('theme') as Theme;
-    if (savedTheme) {
-      setTheme(savedTheme);
+  const applyDarkTheme = useCallback(() => {
+    setTheme('dark');
+    document.documentElement.classList.add('dark');
+    try {
+      localStorage.setItem('theme', 'dark');
+    } catch (error) {
+      // storage might be unavailable; ignore
     }
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('theme', theme);
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
+    applyDarkTheme();
+  }, [applyDarkTheme]);
 
-  const toggleTheme = () => {
-    setTheme(prev => prev === 'light' ? 'dark' : 'light');
-  };
+  const toggleTheme = useCallback(() => {
+    applyDarkTheme();
+  }, [applyDarkTheme]);
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,18 +1,118 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { useTheme } from '@/contexts/ThemeContext';
-import { Settings, Moon, Sun, Volume2, Trash2, Download } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { Settings, Moon, Volume2, Trash2, Download, Image, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { BackButton } from '@/components/ui/back-button';
+import { useAuth } from '@/contexts/AuthContext';
+import { updateTeamLogo } from '@/services/team';
+
+const MAX_LOGO_SIZE = 512 * 1024; // 512KB
+const ACCEPTED_LOGO_TYPES = ['image/png', 'image/jpeg', 'image/svg+xml'];
 
 export default function SettingsPage() {
-  const navigate = useNavigate();
-  const { theme, toggleTheme } = useTheme();
+  const { theme } = useTheme();
+  const { user, refreshTeamInfo } = useAuth();
+  const [logoPreview, setLogoPreview] = useState<string | null>(user?.teamLogo ?? null);
+  const [isSavingLogo, setIsSavingLogo] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const acceptedLogoTypes = ACCEPTED_LOGO_TYPES.join(',');
+
+  useEffect(() => {
+    setLogoPreview(user?.teamLogo ?? null);
+  }, [user?.teamLogo]);
+
+  const readFileAsDataUrl = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result === 'string') {
+          resolve(result);
+        } else {
+          reject(new Error('Logo dönüştürülemedi.'));
+        }
+      };
+      reader.onerror = () => reject(new Error('Logo okunurken bir hata oluştu.'));
+      reader.readAsDataURL(file);
+    });
+
+  const handleLogoUpload = async (file: File) => {
+    if (!user) {
+      toast.error('Logo yüklemek için giriş yapmalısın.');
+      return;
+    }
+
+    const fileType = file.type?.toLowerCase();
+    if (!fileType || !ACCEPTED_LOGO_TYPES.includes(fileType)) {
+      toast.error('Desteklenmeyen dosya formatı.', {
+        description: 'Lütfen PNG, JPG veya SVG formatında bir görsel yükleyin.',
+      });
+      return;
+    }
+
+    if (file.size > MAX_LOGO_SIZE) {
+      toast.error('Logo dosyası çok büyük.', {
+        description: '512 KB\'dan küçük bir görsel seçmelisin.',
+      });
+      return;
+    }
+
+    setIsSavingLogo(true);
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      await updateTeamLogo(user.id, dataUrl);
+      setLogoPreview(dataUrl);
+      toast.success('Takım logon başarıyla güncellendi.');
+      await refreshTeamInfo();
+    } catch (error) {
+      console.error('[Settings] Logo update failed', error);
+      toast.error('Logo kaydedilemedi.', {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsSavingLogo(false);
+    }
+  };
+
+  const handleLogoFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) {
+      return;
+    }
+    await handleLogoUpload(file);
+  };
+
+  const handleRemoveLogo = async () => {
+    if (!user) {
+      return;
+    }
+    setIsSavingLogo(true);
+    try {
+      await updateTeamLogo(user.id, null);
+      setLogoPreview(null);
+      toast.success('Takım logon kaldırıldı.');
+      await refreshTeamInfo();
+    } catch (error) {
+      console.error('[Settings] Logo remove failed', error);
+      toast.error('Logo kaldırılırken bir hata oluştu.', {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsSavingLogo(false);
+    }
+  };
+
+  const openFileDialog = () => {
+    if (!isSavingLogo) {
+      fileInputRef.current?.click();
+    }
+  };
 
   const handleClearCache = () => {
     toast.success('Önbellek temizlendi');
@@ -22,230 +122,302 @@ export default function SettingsPage() {
     toast.success('Veriler dışa aktarıldı');
   };
 
+  const cardBaseClass = 'border-white/10 bg-slate-900/60 text-slate-100 backdrop-blur-lg';
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 dark:from-green-950 dark:via-emerald-950 dark:to-teal-950">
-      {/* Header */}
-      <div className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-b p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <BackButton />
-            <h1 className="text-xl font-bold">Ayarlar</h1>
-          </div>
-        </div>
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-emerald-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-24 top-0 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
+        <div className="absolute right-[-20%] bottom-[-25%] h-[28rem] w-[28rem] rounded-full bg-cyan-500/10 blur-3xl" />
       </div>
 
-      <div className="p-4 space-y-6">
-        {/* Appearance */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              {theme === 'light' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
-              Görünüm
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
+      <div className="relative z-10 flex flex-col gap-6 px-4 py-8 sm:px-6 lg:px-10">
+        <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-4 sm:p-6 backdrop-blur-lg">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <BackButton />
               <div>
-                <Label className="font-medium">Koyu Tema</Label>
-                <p className="text-sm text-muted-foreground">Gözlerinizi yormasın diye koyu tema kullanın</p>
+                <h1 className="text-3xl font-bold">Ayarlar</h1>
+                <p className="mt-1 text-sm text-slate-300">
+                  Kulübünü kişiselleştir, bildirim tercihlerini düzenle ve verilerini yönet.
+                </p>
               </div>
-              <Switch 
-                checked={theme === 'dark'} 
-                onCheckedChange={toggleTheme}
+            </div>
+            <div className="flex items-center gap-2 rounded-xl border border-emerald-300/30 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-100 shadow-lg">
+              <Moon className="h-4 w-4" />
+              <span>Tema: {theme === 'dark' ? 'Koyu' : 'Açık'}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
+          <Card className={cardBaseClass}>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <Image className="h-5 w-5 text-emerald-300" />
+                Takım Kimliği
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-sm text-slate-300">
+                Logonu yükleyerek kulübünü diğer menajerlerden ayır. PNG, JPG veya SVG formatında en fazla 512 KB boyutunda bir
+                görsel seçebilirsin.
+              </p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={acceptedLogoTypes}
+                className="hidden"
+                onChange={handleLogoFileChange}
               />
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Notifications */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Bildirimler</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <Label className="font-medium">Maç Bildirimleri</Label>
-                <p className="text-sm text-muted-foreground">Maç başlamadan önce bildirim al</p>
-              </div>
-              <Switch defaultChecked />
-            </div>
-            
-            <div className="flex items-center justify-between">
-              <div>
-                <Label className="font-medium">Antrenman Bildirimleri</Label>
-                <p className="text-sm text-muted-foreground">Antrenman tamamlandığında bildirim al</p>
-              </div>
-              <Switch defaultChecked />
-            </div>
-            
-            <div className="flex items-center justify-between">
-              <div>
-                <Label className="font-medium">Transfer Bildirimleri</Label>
-                <p className="text-sm text-muted-foreground">Transfer döneminde fırsatlar için bildirim al</p>
-              </div>
-              <Switch />
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Language & Region */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Dil ve Bölge</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label>Dil</Label>
-              <Select defaultValue="tr">
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="tr">Türkçe</SelectItem>
-                  <SelectItem value="en">English</SelectItem>
-                  <SelectItem value="de">Deutsch</SelectItem>
-                  <SelectItem value="es">Español</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            
-            <div className="space-y-2">
-              <Label>Para Birimi</Label>
-              <Select defaultValue="try">
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="try">Türk Lirası (₺)</SelectItem>
-                  <SelectItem value="eur">Euro (€)</SelectItem>
-                  <SelectItem value="usd">US Dollar ($)</SelectItem>
-                  <SelectItem value="gbp">British Pound (£)</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Audio & Performance */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Volume2 className="h-5 w-5" />
-              Ses ve Performans
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <Label className="font-medium">Ses Efektleri</Label>
-                <p className="text-sm text-muted-foreground">Maç sırasında ses efektlerini oynat</p>
-              </div>
-              <Switch defaultChecked />
-            </div>
-            
-            <div className="flex items-center justify-between">
-              <div>
-                <Label className="font-medium">Animasyonlar</Label>
-                <p className="text-sm text-muted-foreground">Geçiş animasyonlarını azalt</p>
-              </div>
-              <Switch />
-            </div>
-            
-            <div className="space-y-2">
-              <Label>Grafik Kalitesi</Label>
-              <Select defaultValue="high">
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="low">Düşük</SelectItem>
-                  <SelectItem value="medium">Orta</SelectItem>
-                  <SelectItem value="high">Yüksek</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Data Management */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Settings className="h-5 w-5" />
-              Veri Yönetimi
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-3">
-              <Button 
-                variant="outline" 
-                className="w-full justify-start h-12"
-                onClick={handleExportData}
-              >
-                <Download className="h-4 w-4 mr-2" />
-                Verileri Dışa Aktar
-              </Button>
-              
-              <Button 
-                variant="outline" 
-                className="w-full justify-start h-12"
-                onClick={handleClearCache}
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Önbelleği Temizle
-              </Button>
-            </div>
-            
-            <div className="pt-4 border-t">
-              <div className="space-y-2 text-sm text-muted-foreground">
-                <div className="flex justify-between">
-                  <span>Oyun Verisi:</span>
-                  <span>2.4 MB</span>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-2xl border border-emerald-300/30 bg-slate-950/70 shadow-inner">
+                  {logoPreview ? (
+                    <img src={logoPreview} alt="Takım logosu" className="h-full w-full object-cover" />
+                  ) : (
+                    <span className="text-3xl">⚽</span>
+                  )}
                 </div>
-                <div className="flex justify-between">
-                  <span>Önbellek:</span>
-                  <span>15.8 MB</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>Toplam:</span>
-                  <span>18.2 MB</span>
+                <div className="space-y-3">
+                  <div className="flex flex-wrap gap-3">
+                    <Button
+                      onClick={openFileDialog}
+                      disabled={!user || isSavingLogo}
+                      className="bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30"
+                    >
+                      {isSavingLogo ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Kaydediliyor
+                        </>
+                      ) : (
+                        'Logo Yükle'
+                      )}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      onClick={handleRemoveLogo}
+                      disabled={!user || isSavingLogo || !logoPreview}
+                      className="text-slate-300 hover:text-emerald-100"
+                    >
+                      Logoyu Kaldır
+                    </Button>
+                  </div>
+                  <p className="text-xs text-slate-400">
+                    {user?.teamName ?? 'Takımın'} logosu yenilendiğinde üst menüde ve diğer sayfalarda otomatik olarak güncellenir.
+                  </p>
                 </div>
               </div>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
 
-        {/* About */}
-        <Card>
+          <Card className={cardBaseClass}>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Moon className="h-5 w-5 text-emerald-300" />
+                Görünüm
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-slate-300">
+                Oyun deneyimini tutarlı kılmak için koyu tema varsayılan hale getirildi ve tüm kullanıcılar için etkin.
+              </p>
+              <p className="text-xs text-slate-400">
+                Sistem temandan bağımsız olarak arayüz koyu modda açılır. Gelecekteki güncellemelerde farklı tema seçenekleri
+                eklenebilir.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card className={cardBaseClass}>
+            <CardHeader>
+              <CardTitle>Bildirimler</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="font-medium">Maç Bildirimleri</Label>
+                  <p className="text-sm text-slate-400">Maç başlamadan önce bildirim al</p>
+                </div>
+                <Switch defaultChecked />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="font-medium">Antrenman Bildirimleri</Label>
+                  <p className="text-sm text-slate-400">Antrenman tamamlandığında bildirim al</p>
+                </div>
+                <Switch defaultChecked />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="font-medium">Transfer Bildirimleri</Label>
+                  <p className="text-sm text-slate-400">Transfer döneminde fırsatlar için bildirim al</p>
+                </div>
+                <Switch />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className={cardBaseClass}>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Volume2 className="h-5 w-5 text-emerald-300" />
+                Ses ve Performans
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="font-medium">Ses Efektleri</Label>
+                  <p className="text-sm text-slate-400">Maç sırasında ses efektlerini oynat</p>
+                </div>
+                <Switch defaultChecked />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="font-medium">Animasyonlar</Label>
+                  <p className="text-sm text-slate-400">Geçiş animasyonlarını azalt</p>
+                </div>
+                <Switch />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Grafik Kalitesi</Label>
+                <Select defaultValue="high">
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="low">Düşük</SelectItem>
+                    <SelectItem value="medium">Orta</SelectItem>
+                    <SelectItem value="high">Yüksek</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card className={cardBaseClass}>
+            <CardHeader>
+              <CardTitle>Dil ve Bölge</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label>Dil</Label>
+                <Select defaultValue="tr">
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="tr">Türkçe</SelectItem>
+                    <SelectItem value="en">English</SelectItem>
+                    <SelectItem value="de">Deutsch</SelectItem>
+                    <SelectItem value="es">Español</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Para Birimi</Label>
+                <Select defaultValue="try">
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="try">Türk Lirası (₺)</SelectItem>
+                    <SelectItem value="eur">Euro (€)</SelectItem>
+                    <SelectItem value="usd">US Dollar ($)</SelectItem>
+                    <SelectItem value="gbp">British Pound (£)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className={cardBaseClass}>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Settings className="h-5 w-5 text-emerald-300" />
+                Veri Yönetimi
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-3">
+                <Button
+                  variant="outline"
+                  className="w-full justify-start border-white/20 bg-white/5 text-slate-100 hover:bg-white/10"
+                  onClick={handleExportData}
+                >
+                  <Download className="mr-2 h-4 w-4" />
+                  Verileri Dışa Aktar
+                </Button>
+
+                <Button
+                  variant="outline"
+                  className="w-full justify-start border-white/20 bg-white/5 text-slate-100 hover:bg-white/10"
+                  onClick={handleClearCache}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Önbelleği Temizle
+                </Button>
+              </div>
+
+              <div className="border-t border-white/10 pt-4">
+                <div className="space-y-2 text-sm text-slate-300">
+                  <div className="flex justify-between">
+                    <span>Oyun Verisi:</span>
+                    <span>2.4 MB</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Önbellek:</span>
+                    <span>15.8 MB</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Toplam:</span>
+                    <span>18.2 MB</span>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card className={cardBaseClass}>
           <CardHeader>
             <CardTitle>Hakkında</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-3 text-sm">
+            <div className="space-y-3 text-sm text-slate-300">
               <div className="flex justify-between">
-                <span className="text-muted-foreground">Versiyon:</span>
+                <span className="text-slate-400">Versiyon:</span>
                 <span>1.0.0</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted-foreground">Son Güncelleme:</span>
+                <span className="text-slate-400">Son Güncelleme:</span>
                 <span>18 Ağustos 2025</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted-foreground">Geliştirici:</span>
+                <span className="text-slate-400">Geliştirici:</span>
                 <span>Turhan KAYAER</span>
               </div>
             </div>
-            
-            <div className="mt-4 pt-4 border-t">
+
+            <div className="mt-4 border-t border-white/10 pt-4">
               <div className="space-y-2">
-                <Button variant="ghost" className="w-full justify-start text-sm p-0 h-auto">
+                <Button variant="ghost" className="w-full justify-start text-sm text-slate-200 hover:text-emerald-100">
                   Gizlilik Politikası
                 </Button>
-                <Button variant="ghost" className="w-full justify-start text-sm p-0 h-auto">
+                <Button variant="ghost" className="w-full justify-start text-sm text-slate-200 hover:text-emerald-100">
                   Kullanım Şartları
                 </Button>
-                <Button variant="ghost" className="w-full justify-start text-sm p-0 h-auto">
+                <Button variant="ghost" className="w-full justify-start text-sm text-slate-200 hover:text-emerald-100">
                   Destek
                 </Button>
               </div>

--- a/src/pages/TransferMarket.tsx
+++ b/src/pages/TransferMarket.tsx
@@ -47,6 +47,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { PlayerStatusCard } from '@/components/ui/player-status-card';
 import { cn } from '@/lib/utils';
+import './transfer-market.css';
 
 const POSITIONS: Player['position'][] = [
   'GK',
@@ -412,7 +413,8 @@ export default function TransferMarket() {
         <TableRow
           key={listing.id}
           className={cn(
-            isExpanded && 'bg-emerald-50/50 dark:bg-emerald-900/30',
+            'transition-colors',
+            isExpanded && 'bg-emerald-500/10',
           )}
         >
           <TableCell>
@@ -464,11 +466,13 @@ export default function TransferMarket() {
             )}
           </TableCell>
           <TableCell>
-            <Badge variant="outline">{position}</Badge>
+            <Badge variant="outline" className="border-white/20 bg-white/5 text-slate-100">
+              {position}
+            </Badge>
           </TableCell>
-          <TableCell>{formatOverall(overallValue)}</TableCell>
-          <TableCell>{listing.sellerTeamName}</TableCell>
-          <TableCell className="font-medium text-emerald-600">
+          <TableCell className="text-slate-200">{formatOverall(overallValue)}</TableCell>
+          <TableCell className="text-slate-300">{listing.sellerTeamName}</TableCell>
+          <TableCell className="font-semibold text-emerald-300">
             {formatPrice(listing.price)}
           </TableCell>
           <TableCell className="text-right">
@@ -480,6 +484,7 @@ export default function TransferMarket() {
                 purchasingId === listing.id ||
                 teamBudget < listing.price
               }
+              className="bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30"
             >
               {purchasingId === listing.id ? (
                 <>
@@ -499,7 +504,7 @@ export default function TransferMarket() {
   const renderMobileListings = () => {
     if (isListingsLoading) {
       return (
-        <div className="flex items-center justify-center gap-2 rounded-lg border border-dashed border-muted-foreground/40 bg-white/70 py-6 text-sm text-muted-foreground dark:bg-slate-900/40">
+        <div className="flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/5 py-6 text-sm text-slate-300">
           <Loader2 className="h-4 w-4 animate-spin" />
           İlanlar yükleniyor...
         </div>
@@ -508,7 +513,7 @@ export default function TransferMarket() {
 
     if (listings.length === 0) {
       return (
-        <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-white/70 p-4 text-center text-sm text-muted-foreground dark:bg-slate-900/40">
+        <div className="rounded-xl border border-white/20 bg-white/5 p-4 text-center text-sm text-slate-300">
           Filtrenize uyan aktif ilan bulunamadı.
         </div>
       );
@@ -526,7 +531,7 @@ export default function TransferMarket() {
       return (
         <div
           key={listing.id}
-          className="rounded-xl border border-emerald-100 bg-white/70 p-4 shadow-sm dark:border-emerald-900/50 dark:bg-slate-900/60"
+          className="transfer-market-mobile-card"
         >
           <div className="flex items-start justify-between gap-3">
             <div>
@@ -535,7 +540,9 @@ export default function TransferMarket() {
                 Yaş {ageDisplay} · Potansiyel {formatOverall(potentialValue)}
               </div>
             </div>
-            <Badge variant="outline">{position}</Badge>
+            <Badge variant="outline" className="border-white/20 bg-white/5 text-slate-100">
+              {position}
+            </Badge>
           </div>
           <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-muted-foreground">
             <div>
@@ -548,11 +555,11 @@ export default function TransferMarket() {
             </div>
             <div>
               <span className="font-medium text-foreground">Fiyat</span>
-              <div className="text-sm font-semibold text-emerald-600">{formatPrice(listing.price)}</div>
+              <div className="transfer-market-mobile-card__price">{formatPrice(listing.price)}</div>
             </div>
           </div>
           <Button
-            className="mt-4 w-full"
+            className="mt-4 w-full bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30"
             onClick={() => handlePurchase(listing)}
             disabled={
               sellerUid === user?.id ||
@@ -685,46 +692,55 @@ export default function TransferMarket() {
   };
 
   return (
-    <div className="flex min-h-screen w-full flex-col overflow-x-hidden bg-gradient-to-br from-emerald-50 via-slate-50 to-blue-50 dark:from-emerald-950 dark:via-slate-950 dark:to-blue-950">
-      <div className="flex w-full flex-1 flex-col gap-6 px-4 py-8 sm:px-6 lg:px-10">
-        <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="space-y-2">
+    <div className="transfer-market-page">
+      <div className="transfer-market-gradient" />
+      <div className="transfer-market-orb transfer-market-orb--left" />
+      <div className="transfer-market-orb transfer-market-orb--right" />
+      <div className="transfer-market-noise" />
+      <div className="transfer-market-shell">
+        <header className="transfer-market-header">
+          <div className="transfer-market-header__main">
             <BackButton />
-            <h1 className="text-3xl font-bold">Transfer Pazarı</h1>
-            <p className="text-muted-foreground max-w-2xl">
-              Oyuncularını pazara çıkar, eksik bölgeler için yeni yıldızlar keşfet.
-              Mevkilere, ortalama güce ve fiyata göre filtreleyerek hedeflediğin transferi kolayca bul.
-            </p>
-          </div>
-          <div className="flex items-center gap-3 rounded-lg border bg-white/60 p-4 dark:bg-slate-900/60">
-            <Shield className="h-10 w-10 text-emerald-600" />
-            <div>
-              <p className="text-sm text-muted-foreground">Takım Adı</p>
-              <p className="font-semibold">{teamName || user?.teamName || 'Takımım'}</p>
-              <p className="text-xs text-muted-foreground">Transfer bütçesi: {formatPrice(teamBudget)}</p>
+            <div className="transfer-market-header__title">
+              <h1>Transfer Pazarı</h1>
+              <p>
+                Oyuncularını pazara çıkar, eksik bölgeler için yeni yıldızlar keşfet. Mevkilere, ortalama güce ve fiyata göre
+                filtreleyerek hedeflediğin transferi kolayca bul.
+              </p>
             </div>
           </div>
-        </div>
+          <div className="transfer-market-summary">
+            <div className="transfer-market-summary__icon">
+              <Shield className="h-6 w-6" />
+            </div>
+            <div className="transfer-market-summary__info">
+              <span>Takım</span>
+              <strong>{teamName || user?.teamName || 'Takımım'}</strong>
+            </div>
+            <div className="transfer-market-summary__info">
+              <span>Bütçe</span>
+              <strong>{formatPrice(teamBudget)}</strong>
+            </div>
+          </div>
+        </header>
 
-        <div className="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-          <Card>
-            <CardHeader className="flex flex-col gap-2 border-b bg-white/70 dark:bg-slate-900/60">
+        <div className="transfer-market-layout">
+          <Card className={cn('transfer-market-card', 'overflow-hidden')}>
+            <CardHeader className={cn('transfer-market-card__header')}>
               <CardTitle className="flex items-center gap-2 text-xl">
-                <ShoppingCart className="h-5 w-5" />
+                <ShoppingCart className="h-5 w-5 text-emerald-300" />
                 Pazardaki Oyuncular
               </CardTitle>
-              <div className="grid gap-3 sm:grid-cols-3">
+              <div className="transfer-market-card__filters">
                 <div>
-                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
-                    Mevki
-                  </label>
+                  <label className="text-xs font-medium uppercase text-slate-300">Mevki</label>
                   <Select
                     value={filters.position}
                     onValueChange={value =>
                       setFilters(prev => ({ ...prev, position: value as FilterState['position'] }))
                     }
                   >
-                    <SelectTrigger>
+                    <SelectTrigger className="border-white/20 bg-slate-900/60 text-slate-100">
                       <SelectValue placeholder="Mevki seç" />
                     </SelectTrigger>
                     <SelectContent>
@@ -738,9 +754,7 @@ export default function TransferMarket() {
                   </Select>
                 </div>
                 <div>
-                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
-                    Maksimum Fiyat
-                  </label>
+                  <label className="text-xs font-medium uppercase text-slate-300">Maksimum Fiyat</label>
                   <Input
                     inputMode="numeric"
                     type="number"
@@ -750,26 +764,25 @@ export default function TransferMarket() {
                     onChange={event =>
                       setFilters(prev => ({ ...prev, maxPrice: event.target.value }))
                     }
+                    className="border-white/20 bg-slate-900/60 text-slate-100 placeholder:text-slate-500"
                   />
                 </div>
                 <div>
-                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
-                    Sıralama
-                  </label>
+                  <label className="text-xs font-medium uppercase text-slate-300">Sıralama</label>
                   <Select
                     value={filters.sortBy}
                     onValueChange={value =>
                       setFilters(prev => ({ ...prev, sortBy: value as SortOption }))
                     }
                   >
-                    <SelectTrigger>
+                    <SelectTrigger className="border-white/20 bg-slate-900/60 text-slate-100">
                       <SelectValue placeholder="Sırala" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="overall-desc">Güç (Yüksek &rarr; Düşük)</SelectItem>
-                      <SelectItem value="overall-asc">Güç (Düşük &rarr; Yüksek)</SelectItem>
-                      <SelectItem value="price-asc">Fiyat (Düşük &rarr; Yüksek)</SelectItem>
-                      <SelectItem value="price-desc">Fiyat (Yüksek &rarr; Düşük)</SelectItem>
+                      <SelectItem value="overall-desc">Güç (Yüksek → Düşük)</SelectItem>
+                      <SelectItem value="overall-asc">Güç (Düşük → Yüksek)</SelectItem>
+                      <SelectItem value="price-asc">Fiyat (Düşük → Yüksek)</SelectItem>
+                      <SelectItem value="price-desc">Fiyat (Yüksek → Düşük)</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -777,7 +790,7 @@ export default function TransferMarket() {
             </CardHeader>
             <CardContent className="p-0">
               {isDesktop ? (
-                <div className="w-full overflow-x-auto">
+                <div className="transfer-market-card__table">
                   <Table>
                     <TableHeader>
                       <TableRow>
@@ -793,59 +806,55 @@ export default function TransferMarket() {
                   </Table>
                 </div>
               ) : (
-                <div className="flex w-full flex-col gap-3 p-4">
+                <div className="transfer-market-mobile-listings p-6">
                   {renderMobileListings()}
                 </div>
               )}
             </CardContent>
           </Card>
 
-          <div className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">Transfer Bütçen</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-xs font-medium uppercase text-muted-foreground">Kalan Bütçe</p>
-                    <p className="text-2xl font-semibold">{formatPrice(teamBudget)}</p>
-                  </div>
-                  <Button variant="outline" onClick={handleAddFunds} disabled={isAddingFunds || !user}>
-                    {isAddingFunds ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        Ekleniyor
-                      </>
-                    ) : (
-                      '+10.000 ₺ Ekle'
-                    )}
-                  </Button>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  Test amaçlı bütçene hızlıca para eklemek için bu butonu kullanabilirsin. İşlem Firebase üzerinde kaydedilir.
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-lg">
-                  <PlusCircle className="h-5 w-5" />
-                  Oyuncu İlanı Oluştur
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
+          <div className="transfer-market-aside">
+            <div className="transfer-market-budget">
+              <div className="flex items-center justify-between">
                 <div>
-                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
-                    Oyuncu Seç
-                  </label>
+                  <p className="transfer-market-budget__label">Kalan Bütçe</p>
+                  <p className="transfer-market-budget__value">{formatPrice(teamBudget)}</p>
+                </div>
+                <Button
+                  variant="outline"
+                  onClick={handleAddFunds}
+                  disabled={isAddingFunds || !user}
+                  className="border-white/20 bg-white/5 text-slate-100 hover:bg-emerald-500/20"
+                >
+                  {isAddingFunds ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Ekleniyor
+                    </>
+                  ) : (
+                    '+10.000 ₺ Ekle'
+                  )}
+                </Button>
+              </div>
+              <p className="mt-4 text-xs text-slate-400">
+                Test amaçlı bütçene hızlıca para eklemek için bu butonu kullanabilirsin. İşlem Firebase üzerinde kaydedilir.
+              </p>
+            </div>
+
+            <div className="transfer-market-form">
+              <h2 className="flex items-center gap-2 text-lg font-semibold text-white">
+                <PlusCircle className="h-5 w-5 text-emerald-300" />
+                Oyuncu İlanı Oluştur
+              </h2>
+              <div className="mt-4 space-y-4">
+                <div>
+                  <label className="text-xs font-medium uppercase text-slate-300">Oyuncu Seç</label>
                   <Select
                     value={selectedPlayerId}
                     onValueChange={value => setSelectedPlayerId(value)}
                     disabled={availablePlayers.length === 0 || isListing || isLoadingTeam}
                   >
-                    <SelectTrigger>
+                    <SelectTrigger className="border-white/20 bg-slate-900/60 text-slate-100">
                       <SelectValue
                         placeholder={
                           isLoadingTeam
@@ -866,9 +875,7 @@ export default function TransferMarket() {
                   </Select>
                 </div>
                 <div>
-                  <label className="block text-xs font-medium uppercase text-muted-foreground mb-1">
-                    Satış Fiyatı (₺)
-                  </label>
+                  <label className="text-xs font-medium uppercase text-slate-300">Satış Fiyatı (₺)</label>
                   <Input
                     type="number"
                     inputMode="numeric"
@@ -878,10 +885,11 @@ export default function TransferMarket() {
                     value={price}
                     onChange={event => setPrice(event.target.value)}
                     disabled={isListing}
+                    className="border-white/20 bg-slate-900/60 text-slate-100 placeholder:text-slate-500"
                   />
                 </div>
                 <Button
-                  className="w-full"
+                  className="w-full bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30"
                   onClick={handleCreateListing}
                   disabled={!selectedPlayerId || !price || isListing}
                 >
@@ -894,29 +902,27 @@ export default function TransferMarket() {
                     'Pazara Ekle'
                   )}
                 </Button>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-slate-400">
                   İlan verdiğin oyuncular satılana kadar kadronda görünmeye devam eder. Satış gerçekleştiğinde oyuncu yeni
                   takımına otomatik olarak transfer edilir.
                 </p>
-              </CardContent>
-            </Card>
+              </div>
+            </div>
 
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">Aktif İlanların</CardTitle>
-              </CardHeader>
-              <CardContent>
+            <div className="transfer-market-listings">
+              <h2 className="text-lg font-semibold text-white">Aktif İlanların</h2>
+              <div className="mt-4">
                 {isMyListingsLoading ? (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <div className="flex items-center gap-2 text-sm text-slate-300">
                     <Loader2 className="h-4 w-4 animate-spin" />
                     İlanların yükleniyor...
                   </div>
                 ) : myListings.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-sm text-slate-400">
                     Şu anda pazarda aktif ilanların bulunmuyor.
                   </p>
                 ) : (
-                  <ul className="space-y-3">
+                  <ul>
                     {myListings.map(listing => {
                       const player = listing.player;
                       const name = player?.name ?? listing.playerName ?? 'Bilinmeyen Oyuncu';
@@ -924,23 +930,21 @@ export default function TransferMarket() {
                       const overallValue = player?.overall ?? listing.overall ?? 0;
 
                       return (
-                        <li
-                          key={listing.id}
-                          className="flex items-center justify-between rounded-lg border bg-white/70 px-3 py-2 text-sm dark:bg-slate-900/60"
-                        >
+                        <li key={listing.id}>
                           <div className="flex flex-col">
-                            <span className="font-medium">{name}</span>
-                            <span className="text-xs text-muted-foreground">
+                            <span>{name}</span>
+                            <span className="text-xs text-slate-400">
                               {position} · Overall {formatOverall(overallValue)}
                             </span>
                           </div>
                           <div className="flex items-center gap-3">
-                            <span className="font-semibold text-emerald-600">{formatPrice(listing.price)}</span>
+                            <span>{formatPrice(listing.price)}</span>
                             <Button
                               variant="outline"
                               size="sm"
                               onClick={() => handleCancelListing(listing.id)}
                               disabled={cancellingId === listing.id}
+                              className="border-white/20 bg-white/5 text-slate-100 hover:bg-emerald-500/20"
                             >
                               {cancellingId === listing.id ? (
                                 <>
@@ -957,8 +961,8 @@ export default function TransferMarket() {
                     })}
                   </ul>
                 )}
-              </CardContent>
-            </Card>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/transfer-market.css
+++ b/src/pages/transfer-market.css
@@ -1,0 +1,302 @@
+.transfer-market-page {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background: radial-gradient(circle at top left, #111827 0%, #0b1322 45%, #020617 100%);
+  color: #e2e8f0;
+}
+
+.transfer-market-gradient {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(168, 85, 247, 0.15));
+  mix-blend-mode: screen;
+  animation: market-gradient 18s ease-in-out infinite alternate;
+}
+
+.transfer-market-orb {
+  position: absolute;
+  width: clamp(280px, 40vw, 520px);
+  height: clamp(280px, 40vw, 520px);
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.6;
+  animation: market-orb-drift 24s ease-in-out infinite alternate;
+}
+
+.transfer-market-orb--left {
+  top: -15%;
+  left: -10%;
+  background: radial-gradient(circle, rgba(6, 182, 212, 0.9) 0%, rgba(6, 182, 212, 0) 70%);
+}
+
+.transfer-market-orb--right {
+  bottom: -25%;
+  right: -5%;
+  background: radial-gradient(circle, rgba(129, 140, 248, 0.85) 0%, rgba(129, 140, 248, 0) 70%);
+  animation-delay: 5s;
+}
+
+.transfer-market-noise {
+  position: absolute;
+  inset: 0;
+  opacity: 0.12;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.2) 1px, transparent 0);
+  background-size: 4px 4px;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.transfer-market-shell {
+  position: relative;
+  z-index: 1;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(3rem, 5vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem) clamp(4rem, 6vw, 5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 3vw, 3rem);
+}
+
+.transfer-market-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .transfer-market-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.transfer-market-header__main {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.transfer-market-header__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.transfer-market-header__title h1 {
+  font-size: clamp(2.25rem, 3.2vw, 2.8rem);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.transfer-market-header__title p {
+  max-width: 36rem;
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.6;
+}
+
+.transfer-market-summary {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  padding: 1.25rem 1.5rem;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 24px 45px rgba(6, 12, 31, 0.4);
+}
+
+.transfer-market-summary__icon {
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 12px;
+  background: rgba(16, 185, 129, 0.2);
+  color: rgba(110, 231, 183, 0.9);
+}
+
+.transfer-market-summary__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.transfer-market-summary__info span {
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.transfer-market-summary__info strong {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.transfer-market-layout {
+  display: grid;
+  gap: clamp(1.75rem, 2.5vw, 2.5rem);
+}
+
+@media (min-width: 1024px) {
+  .transfer-market-layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    align-items: start;
+  }
+}
+
+.transfer-market-card {
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 28px 50px rgba(6, 12, 31, 0.45);
+  backdrop-filter: blur(18px);
+  color: #e2e8f0;
+}
+
+.transfer-market-card__header {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  padding-bottom: 1.5rem !important;
+}
+
+.transfer-market-card__filters {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .transfer-market-card__filters {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.transfer-market-card__table {
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(8, 15, 32, 0.55);
+}
+
+.transfer-market-card__table table {
+  color: inherit;
+}
+
+.transfer-market-card__table thead {
+  background: rgba(12, 21, 38, 0.85);
+}
+
+.transfer-market-card__table th {
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.transfer-market-card__table tbody tr {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.transfer-market-card__table tbody tr:hover {
+  background: rgba(34, 197, 94, 0.08);
+}
+
+.transfer-market-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.transfer-market-budget,
+.transfer-market-form,
+.transfer-market-listings {
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.6);
+  padding: 1.75rem;
+  backdrop-filter: blur(16px);
+  box-shadow: 0 24px 40px rgba(6, 12, 31, 0.4);
+}
+
+.transfer-market-budget__value {
+  font-size: 2rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.transfer-market-budget__label {
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.transfer-market-listings ul {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.transfer-market-listings li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(8, 15, 32, 0.55);
+  padding: 1rem 1.25rem;
+  color: #e2e8f0;
+}
+
+.transfer-market-listings li span:first-child {
+  font-weight: 600;
+}
+
+.transfer-market-listings li span:last-child {
+  color: rgba(94, 234, 212, 0.9);
+}
+
+.transfer-market-mobile-listings {
+  display: grid;
+  gap: 1rem;
+}
+
+.transfer-market-mobile-card {
+  border-radius: 18px;
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  background: rgba(8, 15, 32, 0.6);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: inherit;
+}
+
+.transfer-market-mobile-card__price {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(94, 234, 212, 0.95);
+}
+
+@keyframes market-orb-drift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(40px, -35px, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(-35px, 35px, 0) scale(1.08);
+  }
+}
+
+@keyframes market-gradient {
+  0% {
+    opacity: 0.45;
+    transform: scale(1) rotate(0deg);
+  }
+  100% {
+    opacity: 0.75;
+    transform: scale(1.1) rotate(3deg);
+  }
+}

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -107,6 +107,7 @@ const generateTeamData = (id: string, name: string, manager: string): ClubTeam =
     manager,
     kitHome: 'home',
     kitAway: 'away',
+    logo: null,
     budget: 0,
     transferBudget: 0,
     players,
@@ -194,6 +195,15 @@ export const updateTeamName = async (userId: string, teamName: string) => {
   await setDoc(
     doc(db, 'teams', userId),
     { name: teamName },
+    { merge: true },
+  );
+};
+
+export const updateTeamLogo = async (userId: string, logo: string | null) => {
+  const payload = sanitizeFirestoreData({ logo: logo ?? null });
+  await setDoc(
+    doc(db, 'teams', userId),
+    payload,
     { merge: true },
   );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,6 +85,7 @@ export interface ClubTeam {
   manager: string;
   kitHome: string;
   kitAway: string;
+  logo?: string | null;
   /** @deprecated use transferBudget */
   budget?: number;
   transferBudget?: number;
@@ -226,7 +227,7 @@ export interface User {
   username: string;
   email: string;
   teamName: string;
-  teamLogo: string;
+  teamLogo: string | null;
   connectedAccounts: {
     google?: boolean;
     apple?: boolean;


### PR DESCRIPTION
## Summary
- add a persistent team logo uploader in settings and refresh the auth context with stored logos
- enforce dark theme usage and surface custom logos in the top bar
- restyle the transfer market with the nostalgia visual theme and supporting styles

## Testing
- pnpm lint *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e438b3e8c8832a9024d8ffb830a00d