### PR TITLE
Customize match preview with club branding

### DIFF
--- a/public/Logo/galatasaray.svg
+++ b/public/Logo/galatasaray.svg
@@ -1,0 +1,11 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gs-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7b0f1a" />
+      <stop offset="100%" stop-color="#fbbf24" />
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="144" height="144" rx="36" fill="url(#gs-gradient)" />
+  <path d="M80 38c-23 0-40 17-40 42s17 42 40 42c12 0 22-4 30-12l-11-11c-5 5-11 8-19 8-14 0-24-11-24-27s10-27 24-27c12 0 22 8 24 21h-21v16h39c1-4 2-8 2-13 0-25-17-39-44-39z" fill="#fff"/>
+  <text x="80" y="118" text-anchor="middle" font-size="32" font-family="'Arial Black', sans-serif" fill="#fff">GS</text>
+</svg>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -331,11 +331,22 @@ export const upcomingMatches: Match[] = [
     id: '1',
     opponent: 'Galatasaray',
     opponentLogo: '🦁',
+    opponentLogoUrl: '/Logo/galatasaray.svg',
     date: '2025-08-20',
     time: '20:00',
     venue: 'home',
     status: 'scheduled',
     competition: 'Süper Lig',
+    venueName: 'Rams Park',
+    opponentStats: {
+      overall: 0.912,
+      form: ['W', 'W', 'D', 'W', 'W'],
+      keyPlayers: [
+        { name: 'Mauro Icardi', position: 'ST', highlight: '15 gol' },
+        { name: 'Kerem Aktürkoğlu', position: 'LW', highlight: '11 asist' },
+        { name: 'Lucas Torreira', position: 'CM', highlight: '%90 pas isabeti' },
+      ],
+    },
   },
   {
     id: '2',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,7 @@ export interface Match {
   id: string;
   opponent: string;
   opponentLogo: string;
+  opponentLogoUrl?: string;
   date: string;
   time: string;
   venue: 'home' | 'away';
@@ -124,6 +125,16 @@ export interface Match {
     away: number;
   };
   competition: string;
+  venueName?: string;
+  opponentStats?: {
+    overall: number;
+    form: Array<'W' | 'D' | 'L'>;
+    keyPlayers: Array<{
+      name: string;
+      position: string;
+      highlight: string;
+    }>;
+  };
 }
 
 export interface Team {


### PR DESCRIPTION
## Summary
- extend match data to store detailed opponent metadata and stadium information
- surface the authenticated club name, logo, overall and recent form in the match preview header
- render richer opponent analysis, including dynamic form badges, key players and a dedicated logo asset

## Testing
- npm run lint *(fails: existing any/no-empty violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5637ce064832aa37f508bddbbb453