### PR TITLE
Fix match preview logo validation regex

### DIFF
--- a/src/pages/MatchPreview.tsx
+++ b/src/pages/MatchPreview.tsx
@@ -185,7 +185,7 @@ export default function MatchPreview() {
     if (!value) return null;
     const trimmed = value.trim();
     if (!trimmed) return null;
-    const looksLikePath = /^(https?:\/\/|\/|\.\/|\.\.\/|data:image\//.test(trimmed);
+    const looksLikePath = /^(https?:\/\/|\/|\.\/|\.\.\/|data:image\/)/.test(trimmed);
     const hasImageExtension = /\.(svg|png|jpe?g|webp|gif)$/i.test(trimmed);
     if (looksLikePath || hasImageExtension || trimmed.includes('/')) {
       return trimmed;


### PR DESCRIPTION
## Summary
- fix the logo validation regex so data URLs no longer throw at runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57b028f20832a906928a595f40094