### PR TITLE
Fix opponent detection in match preview

### DIFF
--- a/src/pages/MatchPreview.tsx
+++ b/src/pages/MatchPreview.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { BackButton } from '@/components/ui/back-button';
 import { useAuth } from '@/contexts/AuthContext';
 import { getTeam } from '@/services/team';
-import { getMyLeagueId, getFixturesForTeam, getLeagueTeams } from '@/services/leagues';
+import { getMyLeagueId, getFixturesForTeamSlotAware, getLeagueTeams } from '@/services/leagues';
 import type { ClubTeam, Fixture, Match, Player } from '@/types';
 
 type KeyPlayer = NonNullable<Match['opponentStats']>['keyPlayers'][number];
@@ -140,7 +140,7 @@ export default function MatchPreview() {
       }
 
       const [fixtures, teams] = await Promise.all([
-        getFixturesForTeam(leagueId, user.id),
+        getFixturesForTeamSlotAware(leagueId, user.id),
         getLeagueTeams(leagueId).catch(() => []),
       ]);
       if (cancelled) return;
@@ -238,7 +238,9 @@ export default function MatchPreview() {
     (async () => {
       const [opponent, opponentFixtures] = await Promise.all([
         getTeam(nextFixture.opponentId).catch(() => null),
-        getFixturesForTeam(nextFixture.leagueId, nextFixture.opponentId).catch(() => []),
+        getFixturesForTeamSlotAware(nextFixture.leagueId, nextFixture.opponentId).catch(
+          () => [],
+        ),
       ]);
 
       if (cancelled) return;


### PR DESCRIPTION
## Summary
- switch the match preview page to use the slot-aware fixture loader so the upcoming opponent and their data come from the real schedule

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e57d485018832aa9f758db7b1efef0